### PR TITLE
Attempt to remove empty question cells

### DIFF
--- a/otter/assign.py
+++ b/otter/assign.py
@@ -881,6 +881,15 @@ def strip_solutions(original_nb_path, stripped_nb_path):
     md_solutions.reverse()
     for i in md_solutions:
         del nb['cells'][i]
+
+    empty_remove = []
+    for i, cell in enumerate(nb['cells']):
+        # Remove any empty cells and the grader.check cell that follows it.
+        if cell['source'].strip() == '...':
+            empty_remove += [i, i+1]
+    empty_remove.reverse()
+    for i in empty_remove:
+        del nb['cells'][i]
     
     # remove output from student version
     remove_output(nb)


### PR DESCRIPTION
Hi there -- have been playing around with otter-grader over the last couple of days for teaching of a course next year. Looks like a really interesting piece of software and seems like it might fit the bill for my use case, so thanks for all of your hard work!

One thing I would like to do (or at least have the possibility for) is to award partial credit: e.g. have a question worth 2 marks, where students get a mark if test A passes, and separately a mark if hidden test B passes. This didn't seem to be something that was easily supported out of the box (unless I missed something, in which case please do let me know) -- however, I did find a workaround of sorts, which is to add cells with empty solutions, e.g.:

````
-- markdown cell
```
BEGIN QUESTION
name: q1_b
points: 1
```

-- new code cell
### BEGIN SOLUTION
### END SOLUTION

-- new code cell
### HIDDEN TEST ###
# test goes here
````

This generates the ok tests nicely, but the generated student file then has an empty cell with `...` where the solution has been substituted, followed by a `grader.check('q1_b')` for the empty cell. As removing the cells manually from the student file and running through the grader seems to work just fine, this MR adds some additional logic which removes those cells.

I have probably done this an ugly/bad/terrible way that misses edge cases, but I am happy to tidy this up if you give me some pointers and/or you think this would be useful.