### PR TITLE
Updates tornado requirement to avoid installation warnings

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,5 +13,5 @@ RUN apt-get update
 RUN apt-get install nano -y
 RUN apt install -y gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
 RUN pip3 install nb2pdf
-RUN pip3 install tornado==5.1.1
+RUN pip3 install tornado>=5.1.1
 RUN pip3 install otter-grader==0.4.7

--- a/otter/gs_generator.py
+++ b/otter/gs_generator.py
@@ -22,7 +22,7 @@ seaborn
 sklearn
 jinja2
 nb2pdf
-tornado==5.1.1
+tornado>=5.1.1
 otter-grader==0.4.7{% if other_requirements %}
 {{ other_requirements }}{% endif %}
 """)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ codecov
 jinja2
 docker
 nb2pdf
-tornado==5.1.1
+tornado>=5.1.1
 otter-grader==0.4.7

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setuptools.setup(
 	],
 	install_requires=[
 		"nb2pdf",
-		"tornado==5.1.1"
+		"tornado>=5.1.1"
 	],
 	scripts=["bin/otter"]
 )

--- a/test/integration/autograder-correct/requirements.txt
+++ b/test/integration/autograder-correct/requirements.txt
@@ -9,6 +9,6 @@ seaborn
 sklearn
 jinja2
 nb2pdf
-tornado==5.1.1
+tornado>=5.1.1
 otter-grader==0.4.7
 tqdm


### PR DESCRIPTION
Updates requirement to use `tornado>=5.1.1` to remove installation warnings when installing with more recent versions of the jupyter notebook.