### PR TITLE
fix quote placement on 'students' text

### DIFF
--- a/docs/_build/_sources/gradescope.md.txt
+++ b/docs/_build/_sources/gradescope.md.txt
@@ -1,6 +1,6 @@
 # Gradescope
 
-Otter-Grader also allows instructors to use Gradescope's autograding system to collect and grade students' submissions. This section assumes that instructors are familiar with Gradescope's interface and know how to set up assignments on Gradescope; for more information on using Gradescope, see their [help pages](https://www.gradescope.com/help#help-center-item-programming-assignments).
+Otter-Grader also allows instructors to use Gradescope's autograding system to collect and grade student's submissions. This section assumes that instructors are familiar with Gradescope's interface and know how to set up assignments on Gradescope; for more information on using Gradescope, see their [help pages](https://www.gradescope.com/help#help-center-item-programming-assignments).
 
 ## Writing Tests for Gradescope
 

--- a/docs/_build/_sources/install.md.txt
+++ b/docs/_build/_sources/install.md.txt
@@ -8,7 +8,7 @@ pip install otter-grader
 
 ## Docker
 
-Otter uses Docker to create containers in which to run the students' submissions. Please make sure that you install Docker and pull our Docker image, which is used to grade the notebooks.
+Otter uses Docker to create containers in which to run the student's submissions. Please make sure that you install Docker and pull our Docker image, which is used to grade the notebooks.
 
 ### Pull from DockerHub
 

--- a/docs/_build/_sources/metadata_files.md.txt
+++ b/docs/_build/_sources/metadata_files.md.txt
@@ -20,7 +20,7 @@ to grade the submissions (assuming no extra requirements, no PDF generation, and
 
 ## Metadata Files
 
-If you are not using a service like Gradescope or Canvas to collect submissions, instructors can also create a simple JSON- or YAML-formatted metadata file for their students' submissions and provide this to Otter.
+If you are not using a service like Gradescope or Canvas to collect submissions, instructors can also create a simple JSON- or YAML-formatted metadata file for their student's submissions and provide this to Otter.
 
 The strucure of the metadata is quite simple: it is a list of 2-item dictionaries, where each dictionary has a student identifier stored as the `identifier` key and the filename of the student's submission as `filename`. An example of each is provided below.
 

--- a/docs/_build/_sources/test_files.md.txt
+++ b/docs/_build/_sources/test_files.md.txt
@@ -1,6 +1,6 @@
 # Test Files
 
-Otter requires OK-formatted tests to check students' work against. These have a very specific format, described in detail in the [OK documentation](https://okpy.github.io/documentation/client.html#ok-client-setup-ok-tests).
+Otter requires OK-formatted tests to check student's work against. These have a very specific format, described in detail in the [OK documentation](https://okpy.github.io/documentation/client.html#ok-client-setup-ok-tests).
 
 ## OK Format Caveats
 

--- a/docs/_build/_sources/tests.md.txt
+++ b/docs/_build/_sources/tests.md.txt
@@ -1,6 +1,6 @@
 # Test Files
 
-Otter requires OK-formatted tests to check students' work against. These have a very specific format, described in detail in the [OK documentation](https://okpy.github.io/documentation/client.html#ok-client-setup-ok-tests).
+Otter requires OK-formatted tests to check student's work against. These have a very specific format, described in detail in the [OK documentation](https://okpy.github.io/documentation/client.html#ok-client-setup-ok-tests).
 
 ## OK Format Caveats
 

--- a/docs/_build/_sources/tests_files.md.txt
+++ b/docs/_build/_sources/tests_files.md.txt
@@ -1,6 +1,6 @@
 # Test Files
 
-Otter requires OK-formatted tests to check students' work against. These have a very specific format, described in detail in the [OK documentation](https://okpy.github.io/documentation/client.html#ok-client-setup-ok-tests).
+Otter requires OK-formatted tests to check student's work against. These have a very specific format, described in detail in the [OK documentation](https://okpy.github.io/documentation/client.html#ok-client-setup-ok-tests).
 
 ## OK Format Caveats
 

--- a/docs/gradescope.md
+++ b/docs/gradescope.md
@@ -1,6 +1,6 @@
 # Gradescope
 
-Otter-Grader also allows instructors to use Gradescope's autograding system to collect and grade students' submissions. This section assumes that instructors are familiar with Gradescope's interface and know how to set up assignments on Gradescope; for more information on using Gradescope, see their [help pages](https://www.gradescope.com/help#help-center-item-programming-assignments).
+Otter-Grader also allows instructors to use Gradescope's autograding system to collect and grade student's submissions. This section assumes that instructors are familiar with Gradescope's interface and know how to set up assignments on Gradescope; for more information on using Gradescope, see their [help pages](https://www.gradescope.com/help#help-center-item-programming-assignments).
 
 ## Writing Tests for Gradescope
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -8,7 +8,7 @@ pip install otter-grader
 
 ## Docker
 
-Otter uses Docker to create containers in which to run the students' submissions. Please make sure that you install Docker and pull our Docker image, which is used to grade the notebooks.
+Otter uses Docker to create containers in which to run the student's submissions. Please make sure that you install Docker and pull our Docker image, which is used to grade the notebooks.
 
 ### Pull from DockerHub
 

--- a/docs/metadata_files.md
+++ b/docs/metadata_files.md
@@ -20,7 +20,7 @@ to grade the submissions (assuming no extra requirements, no PDF generation, and
 
 ## Metadata Files
 
-If you are not using a service like Gradescope or Canvas to collect submissions, instructors can also create a simple JSON- or YAML-formatted metadata file for their students' submissions and provide this to Otter.
+If you are not using a service like Gradescope or Canvas to collect submissions, instructors can also create a simple JSON- or YAML-formatted metadata file for their student's submissions and provide this to Otter.
 
 The strucure of the metadata is quite simple: it is a list of 2-item dictionaries, where each dictionary has a student identifier stored as the `identifier` key and the filename of the student's submission as `filename`. An example of each is provided below.
 

--- a/docs/test_files.md
+++ b/docs/test_files.md
@@ -1,6 +1,6 @@
 # Test Files
 
-Otter requires OK-formatted tests to check students' work against. These have a very specific format, described in detail in the [OK documentation](https://okpy.github.io/documentation/client.html#ok-client-setup-ok-tests).
+Otter requires OK-formatted tests to check student's work against. These have a very specific format, described in detail in the [OK documentation](https://okpy.github.io/documentation/client.html#ok-client-setup-ok-tests).
 
 ## OK Format Caveats
 


### PR DESCRIPTION
I saw from this file https://github.com/ucbds-infra/otter-grader/blob/9d4218a19f64405226db50c2b506886eb80910ff/docs/_build/_sources/using_otter.md.txt which using " student's " rather than " students' "

Thus i think on some other files which use " students' " rather than " student's " is considered as wrong or typo quote `'` placement.