### PR TITLE
Fixing bug when no language is specified

### DIFF
--- a/otter/assign/output.py
+++ b/otter/assign/output.py
@@ -31,7 +31,7 @@ def write_autograder_dir(nb_path, output_nb_path, assignment, args):
         try:
             lang = nb["metadata"]["kernelspec"]["language"].lower()
             assignment.lang = lang
-        except IndexError:
+        except KeyError:
             warnings.warn("Could not auto-parse kernelspec from notebook; assuming Python")
             assignment.lang = "python"
 


### PR DESCRIPTION
When no language is specified, a KeyError is thrown, but the code expects an IndexError