### PR TITLE
Add missing file specifier in environment template

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,7 @@
 # Changelog
 
+* Add missing file specifier in environment template
+
 **v1.1.4:**
 
 * Fixed `KeyError` when kernelspec unparsable from notebook in Otter Assign

--- a/otter/generate/templates/environment.yml
+++ b/otter/generate/templates/environment.yml
@@ -9,4 +9,4 @@ dependencies:
     - r-essentials 
     - r-devtools
     - pip:
-        - -r requirements.txt
+        - -r file:requirements.txt


### PR DESCRIPTION
The conda environment.yml file pulls in the pip requirements.txt file to install many requirements including otter itself.

On a recent version of gradescope (used on 12 Jan 2021) this failed to install any of the pip packages from the requirements file.

Adding the “file:” designation corrects this.