### PR TITLE
Fix to pip config in conda env

### DIFF
--- a/otter/generate/templates/python/environment.yml
+++ b/otter/generate/templates/python/environment.yml
@@ -7,4 +7,4 @@ dependencies:
     - pip
     - nb_conda_kernels
     - pip:
-        - -r file:requirements.txt{% else %}{{ other_environment }}{% endif %}
+        - -r requirements.txt{% else %}{{ other_environment }}{% endif %}


### PR DESCRIPTION
This minor fix removes the currently unsupported prepended "file:"
attribute to the pip configuration in environment.yml.

Fix to issue #272