### PR TITLE
Update conda to 4.10.3 and fix conda build

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -55,8 +55,9 @@ jobs:
       run: |
         sudo apt install build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev
         $CONDA/bin/conda env update -n base -f environment.yml
-        $CONDA/bin/Rscript -e "install.packages('devtools')"
-        $CONDA/bin/Rscript -e "devtools::install_github('ucbds-infra/ottr')" || Rscript -e "devtools::install_github('ucbds-infra/ottr')"
+        $CONDA/bin/Rscript -e "Sys.unsetenv('GITHUB_PAT'); install.packages('devtools')"
+        $CONDA/bin/Rscript -e "Sys.unsetenv('GITHUB_PAT'); devtools::install_github('ucbds-infra/ottr')" || \
+          $CONDA/bin/Rscript -e "Sys.unsetenv('GITHUB_PAT'); devtools::install_github('ucbds-infra/ottr')"
 
     - name: Install nbconvert dependencies
       run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -55,9 +55,9 @@ jobs:
       run: |
         sudo apt install build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev
         $CONDA/bin/conda env update -n base -f environment.yml
-        $CONDA/bin/Rscript -e "Sys.unsetenv('GITHUB_PAT'); install.packages('devtools')"
-        $CONDA/bin/Rscript -e "Sys.unsetenv('GITHUB_PAT'); devtools::install_github('ucbds-infra/ottr')" || \
-          $CONDA/bin/Rscript -e "Sys.unsetenv('GITHUB_PAT'); devtools::install_github('ucbds-infra/ottr')"
+        $CONDA/bin/Rscript -e "install.packages('devtools')"
+        $CONDA/bin/Rscript -e "print(devtools::github_pat(1)); print(Sys.getenv('GITHUB_PAT')); Sys.unsetenv('GITHUB_PAT') print(Sys.getenv('GITHUB)PAT')); devtools::install_github('ucbds-infra/ottr')" || \
+          $CONDA/bin/Rscript -e "print(devtools::github_pat(1)); print(Sys.getenv('GITHUB_PAT')); Sys.unsetenv('GITHUB_PAT') print(Sys.getenv('GITHUB)PAT')); devtools::install_github('ucbds-infra/ottr')"
 
     - name: Install nbconvert dependencies
       run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -56,8 +56,8 @@ jobs:
         sudo apt install build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev
         $CONDA/bin/conda env update -n base -f environment.yml
         $CONDA/bin/Rscript -e "install.packages('devtools')"
-        $CONDA/bin/Rscript -e "Sys.setenv(GITHUB_PAT=devtools::github_pat(1)); print(Sys.getenv('GITHUB_PAT')); devtools::install_github('ucbds-infra/ottr')" || \
-          $CONDA/bin/Rscript -e "Sys.setenv(GITHUB_PAT=devtools::github_pat(1)); print(Sys.getenv('GITHUB_PAT')); devtools::install_github('ucbds-infra/ottr')"
+        $CONDA/bin/Rscript -e "Sys.unsetenv('GITHUB_PAT'); print(Sys.getenv('GITHUB_PAT')); devtools::install_github('ucbds-infra/ottr')" || \
+          $CONDA/bin/Rscript -e "Sys.unsetenv('GITHUB_PAT'); print(Sys.getenv('GITHUB_PAT')); devtools::install_github('ucbds-infra/ottr')"
 
     - name: Install nbconvert dependencies
       run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -56,8 +56,10 @@ jobs:
         sudo apt install build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev
         $CONDA/bin/conda env update -n base -f environment.yml
         $CONDA/bin/Rscript -e "install.packages('devtools')"
-        $CONDA/bin/Rscript -e "Sys.unsetenv('GITHUB_PAT'); print(Sys.getenv('GITHUB_PAT')); devtools::install_github('ucbds-infra/ottr')" || \
-          $CONDA/bin/Rscript -e "Sys.unsetenv('GITHUB_PAT'); print(Sys.getenv('GITHUB_PAT')); devtools::install_github('ucbds-infra/ottr')"
+        tmp_dir=$(mktemp -d)
+        git clone --single-branch -b beta https://github.com/ucbds-infra/ottr.git $tmp_dir
+        cd $tmp_dir
+        $CONDA/bin/Rscript -e "devtools::install()" || $CONDA/bin/Rscript -e "devtools::install()"
 
     - name: Install nbconvert dependencies
       run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -53,9 +53,8 @@ jobs:
 
     - name: Install Python and R packages
       run: |
-        $CONDA/bin/pip install -r requirements.txt
-        $CONDA/bin/pip install -r requirements-test.txt
         sudo apt install build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev
+        $CONDA/bin/conda env update -n base -f environment.yml
         $CONDA/bin/Rscript -e "install.packages('devtools')"
         $CONDA/bin/Rscript -e "devtools::install_github('ucbds-infra/ottr')" || Rscript -e "devtools::install_github('ucbds-infra/ottr')"
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -56,8 +56,8 @@ jobs:
         sudo apt install build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev
         $CONDA/bin/conda env update -n base -f environment.yml
         $CONDA/bin/Rscript -e "install.packages('devtools')"
-        $CONDA/bin/Rscript -e "print(devtools::github_pat(1)); print(Sys.getenv('GITHUB_PAT')); Sys.unsetenv('GITHUB_PAT') print(Sys.getenv('GITHUB)PAT')); devtools::install_github('ucbds-infra/ottr')" || \
-          $CONDA/bin/Rscript -e "print(devtools::github_pat(1)); print(Sys.getenv('GITHUB_PAT')); Sys.unsetenv('GITHUB_PAT') print(Sys.getenv('GITHUB)PAT')); devtools::install_github('ucbds-infra/ottr')"
+        $CONDA/bin/Rscript -e "print(devtools::github_pat(1)); print(Sys.getenv('GITHUB_PAT')); Sys.unsetenv('GITHUB_PAT'); print(Sys.getenv('GITHUB)PAT')); devtools::install_github('ucbds-infra/ottr')" || \
+          $CONDA/bin/Rscript -e "print(devtools::github_pat(1)); print(Sys.getenv('GITHUB_PAT')); Sys.unsetenv('GITHUB_PAT'); print(Sys.getenv('GITHUB)PAT')); devtools::install_github('ucbds-infra/ottr')"
 
     - name: Install nbconvert dependencies
       run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -43,7 +43,7 @@ jobs:
       run: |
         sudo -u postgres psql -c "create user root createdb password 'root';"
 
-    - name: Setup Conda
+    - name: Set Up Conda
       run: |
         $CONDA/bin/conda config --set always_yes yes --set changeps1 no
 
@@ -56,8 +56,8 @@ jobs:
         $CONDA/bin/pip install -r requirements.txt
         $CONDA/bin/pip install -r requirements-test.txt
         sudo apt install build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev
-        Rscript -e "install.packages('devtools')"
-        Rscript -e "devtools::install_github('ucbds-infra/ottr')" || Rscript -e "devtools::install_github('ucbds-infra/ottr')"
+        $CONDA/bin/Rscript -e "install.packages('devtools')"
+        $CONDA/bin/Rscript -e "devtools::install_github('ucbds-infra/ottr')" || Rscript -e "devtools::install_github('ucbds-infra/ottr')"
 
     - name: Install nbconvert dependencies
       run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -56,8 +56,8 @@ jobs:
         sudo apt install build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev
         $CONDA/bin/conda env update -n base -f environment.yml
         $CONDA/bin/Rscript -e "install.packages('devtools')"
-        $CONDA/bin/Rscript -e "print(devtools::github_pat(1)); print(Sys.getenv('GITHUB_PAT')); Sys.unsetenv('GITHUB_PAT'); print(Sys.getenv('GITHUB)PAT')); devtools::install_github('ucbds-infra/ottr')" || \
-          $CONDA/bin/Rscript -e "print(devtools::github_pat(1)); print(Sys.getenv('GITHUB_PAT')); Sys.unsetenv('GITHUB_PAT'); print(Sys.getenv('GITHUB)PAT')); devtools::install_github('ucbds-infra/ottr')"
+        $CONDA/bin/Rscript -e "Sys.setenv(GITHUB_PAT=devtools::github_pat(1)); print(Sys.getenv('GITHUB_PAT')); devtools::install_github('ucbds-infra/ottr')" || \
+          $CONDA/bin/Rscript -e "Sys.setenv(GITHUB_PAT=devtools::github_pat(1)); print(Sys.getenv('GITHUB_PAT')); devtools::install_github('ucbds-infra/ottr')"
 
     - name: Install nbconvert dependencies
       run: |

--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,6 @@ dependencies:
     - r-devtools
     - pip
     - pip:
-        - -r file:requirements.txt
-        - -r file:requirements-test.txt
-        - -r file:docs/requirements.txt
+        - -r requirements.txt
+        - -r requirements-test.txt
+        - -r docs/requirements.txt

--- a/otter/generate/autograder.py
+++ b/otter/generate/autograder.py
@@ -23,7 +23,7 @@ from ..run.run_autograder.constants import DEFAULT_OPTIONS
 from ..utils import load_default_file
 
 TEMPLATE_DIR = pkg_resources.resource_filename(__name__, "templates")
-MINICONDA_INSTALL_URL = "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.9.2-Linux-x86_64.sh"
+MINICONDA_INSTALL_URL = "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-Linux-x86_64.sh"
 OTTER_ENV_NAME = "otter-env"
 
 def main(tests_path, output_path, config, lang, requirements, overwrite_requirements, environment,

--- a/otter/generate/templates/python/environment.yml
+++ b/otter/generate/templates/python/environment.yml
@@ -7,4 +7,4 @@ dependencies:
     - pip
     - nb_conda_kernels
     - pip:
-        - -r file:requirements.txt{% else %}{{ other_environment }}{% endif %}
+        - -r requirements.txt{% else %}{{ other_environment }}{% endif %}

--- a/otter/generate/templates/r/environment.yml
+++ b/otter/generate/templates/r/environment.yml
@@ -11,4 +11,4 @@ dependencies:
     - r-devtools
     - libgit2
     - pip:
-        - -r file:requirements.txt{% else %}{{ other_environment }}{% endif %}
+        - -r requirements.txt{% else %}{{ other_environment }}{% endif %}

--- a/test/test-assign/gs-autograder-correct/environment.yml
+++ b/test/test-assign/gs-autograder-correct/environment.yml
@@ -7,4 +7,4 @@ dependencies:
     - pip
     - nb_conda_kernels
     - pip:
-        - -r file:requirements.txt
+        - -r requirements.txt

--- a/test/test-assign/gs-autograder-correct/setup.sh
+++ b/test/test-assign/gs-autograder-correct/setup.sh
@@ -20,7 +20,7 @@ apt-get update
 apt-get install -y build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev libcurl4-openssl-dev libgit2-dev
 
 # install conda
-wget -nv -O /autograder/source/miniconda_install.sh "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.9.2-Linux-x86_64.sh"
+wget -nv -O /autograder/source/miniconda_install.sh "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-Linux-x86_64.sh"
 chmod +x /autograder/source/miniconda_install.sh
 /autograder/source/miniconda_install.sh -b
 echo "export PATH=/root/miniconda3/bin:\$PATH" >> /root/.bashrc

--- a/test/test-assign/rmd-autograder-correct/environment.yml
+++ b/test/test-assign/rmd-autograder-correct/environment.yml
@@ -11,4 +11,4 @@ dependencies:
     - r-devtools
     - libgit2
     - pip:
-        - -r file:requirements.txt
+        - -r requirements.txt

--- a/test/test-assign/rmd-autograder-correct/setup.sh
+++ b/test/test-assign/rmd-autograder-correct/setup.sh
@@ -25,7 +25,7 @@ apt-get update
 apt-get install -y build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev libgit2-dev
 
 # install conda
-wget -nv -O /autograder/source/miniconda_install.sh "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.9.2-Linux-x86_64.sh"
+wget -nv -O /autograder/source/miniconda_install.sh "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-Linux-x86_64.sh"
 chmod +x /autograder/source/miniconda_install.sh
 /autograder/source/miniconda_install.sh -b
 echo "export PATH=/root/miniconda3/bin:\$PATH" >> /root/.bashrc

--- a/test/test-run/autograder/source/environment.yml
+++ b/test/test-run/autograder/source/environment.yml
@@ -7,4 +7,4 @@ dependencies:
     - pip
     - nb_conda_kernels
     - pip:
-        - -r file:requirements.txt
+        - -r requirements.txt

--- a/test/test-run/autograder/source/setup.sh
+++ b/test/test-run/autograder/source/setup.sh
@@ -20,7 +20,7 @@ apt-get update
 apt-get install -y build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev libcurl4-openssl-dev libgit2-dev
 
 # install conda
-wget -nv -O /autograder/source/miniconda_install.sh "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.9.2-Linux-x86_64.sh"
+wget -nv -O /autograder/source/miniconda_install.sh "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-Linux-x86_64.sh"
 chmod +x /autograder/source/miniconda_install.sh
 /autograder/source/miniconda_install.sh -b
 echo "export PATH=/root/miniconda3/bin:\$PATH" >> /root/.bashrc

--- a/test/test_generate/test-autograder/autograder-correct/environment.yml
+++ b/test/test_generate/test-autograder/autograder-correct/environment.yml
@@ -7,4 +7,4 @@ dependencies:
     - pip
     - nb_conda_kernels
     - pip:
-        - -r file:requirements.txt
+        - -r requirements.txt

--- a/test/test_generate/test-autograder/autograder-correct/setup.sh
+++ b/test/test_generate/test-autograder/autograder-correct/setup.sh
@@ -20,7 +20,7 @@ apt-get update
 apt-get install -y build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev libcurl4-openssl-dev libgit2-dev
 
 # install conda
-wget -nv -O /autograder/source/miniconda_install.sh "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.9.2-Linux-x86_64.sh"
+wget -nv -O /autograder/source/miniconda_install.sh "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-Linux-x86_64.sh"
 chmod +x /autograder/source/miniconda_install.sh
 /autograder/source/miniconda_install.sh -b
 echo "export PATH=/root/miniconda3/bin:\$PATH" >> /root/.bashrc

--- a/test/test_generate/test-autograder/autograder-custom-env/environment.yml
+++ b/test/test_generate/test-autograder/autograder-custom-env/environment.yml
@@ -5,5 +5,5 @@ dependencies:
 - python=3.7
 - pip
 - pip:
-  - -r file:requirements.txt
+  - -r requirements.txt
 name: otter-env

--- a/test/test_generate/test-autograder/autograder-custom-env/setup.sh
+++ b/test/test_generate/test-autograder/autograder-custom-env/setup.sh
@@ -20,7 +20,7 @@ apt-get update
 apt-get install -y build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev libcurl4-openssl-dev libgit2-dev
 
 # install conda
-wget -nv -O /autograder/source/miniconda_install.sh "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.9.2-Linux-x86_64.sh"
+wget -nv -O /autograder/source/miniconda_install.sh "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-Linux-x86_64.sh"
 chmod +x /autograder/source/miniconda_install.sh
 /autograder/source/miniconda_install.sh -b
 echo "export PATH=/root/miniconda3/bin:\$PATH" >> /root/.bashrc

--- a/test/test_generate/test-autograder/environment.yml
+++ b/test/test_generate/test-autograder/environment.yml
@@ -5,4 +5,4 @@ dependencies:
     - python=3.7
     - pip
     - pip:
-        - -r file:requirements.txt
+        - -r requirements.txt


### PR DESCRIPTION
Updates the conda version to 4.10.3 and removes the unsupported `file:` prefix in environment.yml files.

Closes #272
Alternative to #273