### PR TITLE
Add download HTML attribute to download links for JupyterLab.

### DIFF
--- a/otter/check/notebook.py
+++ b/otter/check/notebook.py
@@ -389,9 +389,9 @@ class Notebook:
         if display_link:
             # create and display output HTML
             out_html = """
-            <p>Your submission has been exported. Click <a href="{}" target="_blank">here</a>
+            <p>Your submission has been exported. Click <a href="{}" download="{}" target="_blank">here</a>
             to download the zip file.</p>
-            """.format(zip_path)
+            """.format(zip_path, zip_path)
 
             display(HTML(out_html))
 


### PR DESCRIPTION
As explained [here](https://github.com/jupyterlab/jupyterlab/issues/5443#issuecomment-540671479) by @jasongrout, JupyterLab will handle download links correctly if the `download` attribute is set.  We will continue investigating ways to smooth this experience in JupyterLab, as it [does come up in other scenarios for our users](https://discourse.jupyter.org/t/how-to-programmatically-generate-download-link/8360), but for our use case with otter for grading, this simple fix should do the trick.

Closes #339.