### PR TITLE
Add `libgomp` to environment.yml for R

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+**Unreleased:**
+
+* Added `libgomp` to R `environment.yml`
+
 **v3.1.0:**
 
 * Added a tool to convert Assign v0-formatted notebooks to v1 format

--- a/otter/generate/templates/r/environment.yml
+++ b/otter/generate/templates/r/environment.yml
@@ -10,5 +10,6 @@ dependencies:
     - r-essentials 
     - r-devtools
     - libgit2
+    - libgomp
     - pip:
         - -r requirements.txt{% else %}{{ other_environment }}{% endif %}

--- a/test/test-assign/rmd-autograder-correct/environment.yml
+++ b/test/test-assign/rmd-autograder-correct/environment.yml
@@ -10,5 +10,6 @@ dependencies:
     - r-essentials 
     - r-devtools
     - libgit2
+    - libgomp
     - pip:
         - -r requirements.txt


### PR DESCRIPTION
Fixes an issue brought up in the [Slack](https://otter-grader.slack.com/archives/CT9QJK4PL/p1630826900072900)