### PR TITLE
Enable loading of docker build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+**Unreleased:**
+
+* Fix loading docker images after building
+
 **v3.1.2:**
 
 * Specify UTF-8 encoding in all `open` calls used for reading JSON for Windows compatibility per [#380](https://github.com/ucbds-infra/otter-grader/issues/380)

--- a/otter/grade/containers.py
+++ b/otter/grade/containers.py
@@ -34,7 +34,7 @@ def build_image(zip_path, base_image, tag):
         docker.build(".", build_args={
             "ZIPPATH": zip_path,
             "BASE_IMAGE": base_image
-        }, tags=[image], file=dockerfile)
+        }, tags=[image], file=dockerfile, load=True)
 
     return image
 


### PR DESCRIPTION
In some complex setups the load flag must be enabled. It should not cause any problems on more simple setups. 