### PR TITLE
Switch to `texlive-lang-chinese`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Unreleased:**
 
 * Added the question name to the `otter.assign.utils.AssignNotebookFormatException` per [#398](https://github.com/ucbds-infra/otter-grader/issues/398)
+* Switched from manual install of the fandol font in grading images to installing the `texlive-lang-chinese` package
 
 **v3.1.3:**
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,20 +35,11 @@ RUN apt-get clean && \
 RUN apt-get clean && \
     apt-get update && \ 
     apt-get install -y pandoc && \
-    apt-get install -y -f texlive-xetex texlive-fonts-recommended && \
+    apt-get install -y -f texlive-xetex texlive-fonts-recommended texlive-lang-chinese && \
     wget --quiet -O /tmp/wkhtmltopdf.deb https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.focal_amd64.deb && \
     apt-get install -y /tmp/wkhtmltopdf.deb && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
-# install fandol font for xeCJK
-RUN wget -nv -O /tmp/fandol.zip https://mirrors.ctan.org/fonts/fandol.zip && \
-    unzip -d /tmp/fandol /tmp/fandol.zip && \
-    mkdir -p /usr/share/texlive/texmf-dist/fonts/opentype/public/fandol && \
-    cp /tmp/fandol/fandol/*.otf /usr/share/texlive/texmf-dist/fonts/opentype/public/fandol && \
-    mktexlsr && \
-    fc-cache && \
-    rm -rf /tmp/fandol /tmp/fandol.zip
 
 # Set the locale to UTF-8 to ensure that Unicode output is encoded correctly
 ENV LANG C.UTF-8

--- a/otter/generate/templates/python/setup.sh
+++ b/otter/generate/templates/python/setup.sh
@@ -3,19 +3,11 @@
 if [ "${BASE_IMAGE}" != "ucbdsinfra/otter-grader" ]; then
     apt-get clean
     apt-get update
-    apt-get install -y pandoc texlive-xetex texlive-fonts-recommended texlive-generic-recommended build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev libgit2-dev
+    apt-get install -y pandoc texlive-xetex texlive-fonts-recommended texlive-generic-recommended build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev libgit2-dev texlive-lang-chinese
 
     # install wkhtmltopdf
     wget --quiet -O /tmp/wkhtmltopdf.deb https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.bionic_amd64.deb
     apt-get install -y /tmp/wkhtmltopdf.deb
-
-    # install fandol font for xeCJK
-    wget -nv -O /tmp/fandol.zip https://mirrors.ctan.org/fonts/fandol.zip
-    unzip -d /tmp/fandol /tmp/fandol.zip
-    mkdir -p /usr/share/texlive/texmf-dist/fonts/opentype/public/fandol
-    cp /tmp/fandol/fandol/*.otf /usr/share/texlive/texmf-dist/fonts/opentype/public/fandol
-    mktexlsr
-    fc-cache
 
     # install conda
     wget -nv -O {{ autograder_dir }}/source/miniconda_install.sh "{{ miniconda_install_url }}"

--- a/otter/generate/templates/r/setup.sh
+++ b/otter/generate/templates/r/setup.sh
@@ -3,19 +3,11 @@
 if [ "${BASE_IMAGE}" != "ucbdsinfra/otter-grader" ]; then
     apt-get clean
     apt-get update
-    apt-get install -y pandoc texlive-xetex texlive-fonts-recommended texlive-generic-recommended build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev libgit2-dev
+    apt-get install -y pandoc texlive-xetex texlive-fonts-recommended texlive-generic-recommended build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev libgit2-dev texlive-lang-chinese
 
     # install wkhtmltopdf
     wget --quiet -O /tmp/wkhtmltopdf.deb https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.bionic_amd64.deb
     apt-get install -y /tmp/wkhtmltopdf.deb
-
-    # install fandol font for xeCJK
-    wget -nv -O /tmp/fandol.zip https://mirrors.ctan.org/fonts/fandol.zip
-    unzip -d /tmp/fandol /tmp/fandol.zip
-    mkdir -p /usr/share/texlive/texmf-dist/fonts/opentype/public/fandol
-    cp /tmp/fandol/fandol/*.otf /usr/share/texlive/texmf-dist/fonts/opentype/public/fandol
-    mktexlsr
-    fc-cache
 
     # try to set up R
     apt-get clean

--- a/test/test-assign/gs-autograder-correct/setup.sh
+++ b/test/test-assign/gs-autograder-correct/setup.sh
@@ -3,19 +3,11 @@
 if [ "${BASE_IMAGE}" != "ucbdsinfra/otter-grader" ]; then
     apt-get clean
     apt-get update
-    apt-get install -y pandoc texlive-xetex texlive-fonts-recommended texlive-generic-recommended build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev libgit2-dev
+    apt-get install -y pandoc texlive-xetex texlive-fonts-recommended texlive-generic-recommended build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev libgit2-dev texlive-lang-chinese
 
     # install wkhtmltopdf
     wget --quiet -O /tmp/wkhtmltopdf.deb https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.bionic_amd64.deb
     apt-get install -y /tmp/wkhtmltopdf.deb
-
-    # install fandol font for xeCJK
-    wget -nv -O /tmp/fandol.zip https://mirrors.ctan.org/fonts/fandol.zip
-    unzip -d /tmp/fandol /tmp/fandol.zip
-    mkdir -p /usr/share/texlive/texmf-dist/fonts/opentype/public/fandol
-    cp /tmp/fandol/fandol/*.otf /usr/share/texlive/texmf-dist/fonts/opentype/public/fandol
-    mktexlsr
-    fc-cache
 
     # install conda
     wget -nv -O /autograder/source/miniconda_install.sh "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-Linux-x86_64.sh"

--- a/test/test-assign/rmd-autograder-correct/setup.sh
+++ b/test/test-assign/rmd-autograder-correct/setup.sh
@@ -3,19 +3,11 @@
 if [ "${BASE_IMAGE}" != "ucbdsinfra/otter-grader" ]; then
     apt-get clean
     apt-get update
-    apt-get install -y pandoc texlive-xetex texlive-fonts-recommended texlive-generic-recommended build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev libgit2-dev
+    apt-get install -y pandoc texlive-xetex texlive-fonts-recommended texlive-generic-recommended build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev libgit2-dev texlive-lang-chinese
 
     # install wkhtmltopdf
     wget --quiet -O /tmp/wkhtmltopdf.deb https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.bionic_amd64.deb
     apt-get install -y /tmp/wkhtmltopdf.deb
-
-    # install fandol font for xeCJK
-    wget -nv -O /tmp/fandol.zip https://mirrors.ctan.org/fonts/fandol.zip
-    unzip -d /tmp/fandol /tmp/fandol.zip
-    mkdir -p /usr/share/texlive/texmf-dist/fonts/opentype/public/fandol
-    cp /tmp/fandol/fandol/*.otf /usr/share/texlive/texmf-dist/fonts/opentype/public/fandol
-    mktexlsr
-    fc-cache
 
     # try to set up R
     apt-get clean

--- a/test/test_generate/test-autograder/autograder-correct/setup.sh
+++ b/test/test_generate/test-autograder/autograder-correct/setup.sh
@@ -3,19 +3,11 @@
 if [ "${BASE_IMAGE}" != "ucbdsinfra/otter-grader" ]; then
     apt-get clean
     apt-get update
-    apt-get install -y pandoc texlive-xetex texlive-fonts-recommended texlive-generic-recommended build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev libgit2-dev
+    apt-get install -y pandoc texlive-xetex texlive-fonts-recommended texlive-generic-recommended build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev libgit2-dev texlive-lang-chinese
 
     # install wkhtmltopdf
     wget --quiet -O /tmp/wkhtmltopdf.deb https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.bionic_amd64.deb
     apt-get install -y /tmp/wkhtmltopdf.deb
-
-    # install fandol font for xeCJK
-    wget -nv -O /tmp/fandol.zip https://mirrors.ctan.org/fonts/fandol.zip
-    unzip -d /tmp/fandol /tmp/fandol.zip
-    mkdir -p /usr/share/texlive/texmf-dist/fonts/opentype/public/fandol
-    cp /tmp/fandol/fandol/*.otf /usr/share/texlive/texmf-dist/fonts/opentype/public/fandol
-    mktexlsr
-    fc-cache
 
     # install conda
     wget -nv -O /autograder/source/miniconda_install.sh "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-Linux-x86_64.sh"

--- a/test/test_generate/test-autograder/autograder-custom-env/setup.sh
+++ b/test/test_generate/test-autograder/autograder-custom-env/setup.sh
@@ -3,19 +3,11 @@
 if [ "${BASE_IMAGE}" != "ucbdsinfra/otter-grader" ]; then
     apt-get clean
     apt-get update
-    apt-get install -y pandoc texlive-xetex texlive-fonts-recommended texlive-generic-recommended build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev libgit2-dev
+    apt-get install -y pandoc texlive-xetex texlive-fonts-recommended texlive-generic-recommended build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev libgit2-dev texlive-lang-chinese
 
     # install wkhtmltopdf
     wget --quiet -O /tmp/wkhtmltopdf.deb https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.bionic_amd64.deb
     apt-get install -y /tmp/wkhtmltopdf.deb
-
-    # install fandol font for xeCJK
-    wget -nv -O /tmp/fandol.zip https://mirrors.ctan.org/fonts/fandol.zip
-    unzip -d /tmp/fandol /tmp/fandol.zip
-    mkdir -p /usr/share/texlive/texmf-dist/fonts/opentype/public/fandol
-    cp /tmp/fandol/fandol/*.otf /usr/share/texlive/texmf-dist/fonts/opentype/public/fandol
-    mktexlsr
-    fc-cache
 
     # install conda
     wget -nv -O /autograder/source/miniconda_install.sh "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-Linux-x86_64.sh"

--- a/test/test_generate/test-autograder/autograder-token-correct/setup.sh
+++ b/test/test_generate/test-autograder/autograder-token-correct/setup.sh
@@ -3,19 +3,11 @@
 if [ "${BASE_IMAGE}" != "ucbdsinfra/otter-grader" ]; then
     apt-get clean
     apt-get update
-    apt-get install -y pandoc texlive-xetex texlive-fonts-recommended texlive-generic-recommended build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev libgit2-dev
+    apt-get install -y pandoc texlive-xetex texlive-fonts-recommended texlive-generic-recommended build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev libgit2-dev texlive-lang-chinese
 
     # install wkhtmltopdf
     wget --quiet -O /tmp/wkhtmltopdf.deb https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.bionic_amd64.deb
     apt-get install -y /tmp/wkhtmltopdf.deb
-
-    # install fandol font for xeCJK
-    wget -nv -O /tmp/fandol.zip https://mirrors.ctan.org/fonts/fandol.zip
-    unzip -d /tmp/fandol /tmp/fandol.zip
-    mkdir -p /usr/share/texlive/texmf-dist/fonts/opentype/public/fandol
-    cp /tmp/fandol/fandol/*.otf /usr/share/texlive/texmf-dist/fonts/opentype/public/fandol
-    mktexlsr
-    fc-cache
 
     # install conda
     wget -nv -O /autograder/source/miniconda_install.sh "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-Linux-x86_64.sh"


### PR DESCRIPTION
Fixes a bug in the Gradescope image build by using the `texlive-lang-chinese` package instead of manually installing the fandol font.