### PR TITLE
Optimize layer reusage for docker grading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,26 +27,18 @@ tutorial:
 
 docker-grade-test:
 ifeq ($(OS), Darwin)
-	cp otter/generate/templates/python/setup.sh otter/generate/templates/python/old-setup.sh
-	printf "\nconda run -n otter-env pip install /home/otter-grader" >> otter/generate/templates/python/setup.sh
 	sed -i '' -e "s+ucbdsinfra/otter-grader+otter-test+" otter/generate/templates/python/setup.sh
 	sed -i '' -e "s+ucbdsinfra/otter-grader+otter-test+" otter/generate/templates/python/run_autograder
 else
-	cp otter/generate/templates/python/setup.sh otter/generate/templates/python/old-setup.sh
-	printf "\nconda run -n otter-env pip install /home/otter-grader" >> otter/generate/templates/python/setup.sh
 	sed -i "s+ucbdsinfra/otter-grader+otter-test+" otter/generate/templates/python/setup.sh
 	sed -i "s+ucbdsinfra/otter-grader+otter-test+" otter/generate/templates/python/run_autograder
 endif
 
 cleanup-docker-grade-test:
 ifeq ($(OS), Darwin)
-	rm otter/generate/templates/python/setup.sh
-	mv otter/generate/templates/python/old-setup.sh otter/generate/templates/python/setup.sh
 	sed -i '' -e "s+otter-test+ucbdsinfra/otter-grader+" otter/generate/templates/python/setup.sh
 	sed -i '' -e "s+otter-test+ucbdsinfra/otter-grader+" otter/generate/templates/python/run_autograder
 else
-	rm otter/generate/templates/python/setup.sh
-	mv otter/generate/templates/python/old-setup.sh otter/generate/templates/python/setup.sh
 	sed -i "s+otter-test+ucbdsinfra/otter-grader+" otter/generate/templates/python/setup.sh
 	sed -i "s+otter-test+ucbdsinfra/otter-grader+" otter/generate/templates/python/run_autograder
 endif

--- a/otter/generate/utils.py
+++ b/otter/generate/utils.py
@@ -3,13 +3,15 @@
 
 import os
 
-def zip_folder(zf, path, prefix=""):
+def zip_folder(zf, path, prefix="", exclude=[]):
     """
     """
     if not os.path.isabs(path):
         raise ValueError("'path' must be absolute path")
     parent_basename = os.path.basename(path)
     for file in os.listdir(path):
+        if file in exclude:
+            continue
         child_path = os.path.join(path, file)
         if os.path.isfile(child_path):
             arcname = os.path.join(prefix, parent_basename, file)

--- a/otter/grade/Dockerfile
+++ b/otter/grade/Dockerfile
@@ -2,15 +2,13 @@ ARG BASE_IMAGE=ucbdsinfra/otter-grader
 FROM ${BASE_IMAGE}
 RUN apt-get update && apt-get install -y curl unzip dos2unix && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 RUN mkdir -p /autograder/source
-ARG ZIPPATH
 ARG BASE_IMAGE
-RUN echo $BASE_IMAGE
-ADD ${ZIPPATH} /tmp/autograder.zip
 ENV BASE_IMAGE=$BASE_IMAGE
-RUN unzip -d /autograder/source /tmp/autograder.zip && \
-    cp /autograder/source/run_autograder /autograder/run_autograder && \
-    dos2unix /autograder/run_autograder /autograder/source/setup.sh && \
+ADD run_autograder /autograder/run_autograder
+ADD setup.sh environment.yml requirements.* /autograder/source/
+RUN dos2unix /autograder/run_autograder /autograder/source/setup.sh && \
     chmod +x /autograder/run_autograder && \
     apt-get update && bash /autograder/source/setup.sh && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     mkdir -p /autograder/submission && \
     mkdir -p /autograder/results
+ADD . /autograder/source

--- a/test/test_grade.py
+++ b/test/test_grade.py
@@ -7,13 +7,13 @@ import os
 import re
 import shutil
 import subprocess
-import unittest
+import zipfile
 
 from glob import glob
 from subprocess import PIPE
-from unittest import mock
 
 from otter.generate import main as generate
+from otter.generate import utils
 from otter.grade import main as grade
 
 from . import TestCase
@@ -35,8 +35,7 @@ class TestGrade(TestCase):
         with open("otter/grade/Dockerfile", "r+") as f:
             lines = f.readlines()
 
-            idx = max([i if "ARG" in lines[i] else -1 for i in range(len(lines))])
-            lines.insert(idx + 1, "ADD . /home/otter-grader\n")
+            lines.append("\nRUN conda run -n otter-env pip install /autograder/source/otter-grader")
 
             f.seek(0)
             f.write("".join(lines))
@@ -63,6 +62,8 @@ class TestGrade(TestCase):
             config = TEST_FILES_PATH + "otter_config.json" if pdfs else None,
             no_environment = True,
         )
+        with zipfile.ZipFile(TEST_FILES_PATH + "autograder.zip", "a") as zip_ref:
+            utils.zip_folder(zip_ref, os.path.dirname(os.path.dirname(os.path.abspath(__file__))), exclude=[".git", "logo", "test"])
 
     def test_docker(self):
         """


### PR DESCRIPTION
By splitting up the docker image into two steps the building process of similar images can be improved.

If you e.g. only change a test or add further tests the python env doesn't change so rebuilding that part is not required, only new tests must be included inside the new image.  