### PR TITLE
Specify extension for otter grade

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -113,7 +113,7 @@ Let's run Otter on the notebooks:
 
 .. code-block:: console
 
-    otter grade -p submissions/ipynbs -a dist/autograder/autograder.zip --pdfs -v
+    otter grade -p submissions/ipynbs -a dist/autograder/autograder.zip --pdfs -v --ext ipynb
 
 (The ``-v`` flag so that we get verbose output.) After this finishes running, there 
 should be a new file and a new folder in the working directory: ``final_grades.csv`` and 
@@ -180,7 +180,7 @@ grade those:
 
 .. code-block:: console
 
-    otter grade -p submissions/zips -a dist/autograder/autograder.zip -vz
+    otter grade -p submissions/zips -a dist/autograder/autograder.zip -vz --ext ipynb
 
 This should have the same CSV output as above but no ``submission_pdfs`` directory since we didn't 
 tell Otter to generate PDFs.


### PR DESCRIPTION
Without this I see `ValueError: Invalid submission extension specified: None`. I am new to Otter so not sure whether this is due to a recent change in the defaults of `otter grade` or something is wrong on my system, but figured that creating a PR just in case this actually need updating in the docs.