### PR TITLE
Re-open file explicitly when checking if notebook has saved

### DIFF
--- a/otter/check/utils.py
+++ b/otter/check/utils.py
@@ -22,27 +22,26 @@ def save_notebook(filename, timeout=10):
     Args:
         filename (``str``): path to notebook file being saved
         timeout (``int`` or ``float``): number of seconds to wait for save before timing-out
-    
+
     Returns
         ``bool``: whether the notebook was saved successfully
     """
     timeout = timeout * 10**9
     if get_ipython() is not None:
-        f = open(filename, "rb")
-        md5 = hashlib.md5(f.read()).hexdigest()
+        with open(filename, "rb") as f:
+            md5 = hashlib.md5(f.read()).hexdigest()
         start = time.time_ns()
         display(Javascript("Jupyter.notebook.save_checkpoint();"))
-        
+
         curr = md5
         while curr == md5 and time.time_ns() - start <= timeout:
             time.sleep(1)
-            f.seek(0)
-            curr = hashlib.md5(f.read()).hexdigest()
-        
-        f.close()
+            with open(filename, "rb") as f:
+                curr = hashlib.md5(f.read()).hexdigest()
+
 
         return curr != md5
-    
+
     return True
 
 


### PR DESCRIPTION
Am helping debug issues where notebooks are not being
saved properly, and I'm not sure if `f.seek(0)` without
re-opening will always work correctly on NFS. Since we're
expecting another process (notebook server) to write to the
file, it's cleaner to just re-open the file each time we
want to test.