### PR TITLE
Add libmagick++-dev to Gradescope R image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Unreleased:**
 
 * Made `otter.check.utils.save_notebook` compatible with JupyterLab and RetroLab per [#448](https://github.com/ucbds-infra/otter-grader/issues/448)
+* Add `libmagick++-dev` to Gradescope R autograding image
 
 **v3.2.1:**
 

--- a/otter/generate/templates/r/setup.sh
+++ b/otter/generate/templates/r/setup.sh
@@ -3,7 +3,8 @@
 if [ "${BASE_IMAGE}" != "ucbdsinfra/otter-grader" ]; then
     apt-get clean
     apt-get update
-    apt-get install -y pandoc texlive-xetex texlive-fonts-recommended texlive-generic-recommended build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev libgit2-dev texlive-lang-chinese libmagick++-dev
+    apt-get install -y pandoc texlive-xetex texlive-fonts-recommended texlive-generic-recommended build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev libgit2-dev texlive-lang-chinese
+    apt-get install -y libnlopt-dev cmake libfreetype6-dev libpng-dev libtiff5-dev libjpeg-dev apt-utils libpoppler-cpp-dev libavfilter-dev  libharfbuzz-dev libfribidi-dev imagemagick libmagick++-dev pandoc texlive-xetex texlive-fonts-recommended texlive-generic-recommended build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev libgit2-dev texlive-lang-chinese libxft-dev
 
     # install wkhtmltopdf
     wget --quiet -O /tmp/wkhtmltopdf.deb https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.bionic_amd64.deb

--- a/otter/generate/templates/r/setup.sh
+++ b/otter/generate/templates/r/setup.sh
@@ -3,7 +3,7 @@
 if [ "${BASE_IMAGE}" != "ucbdsinfra/otter-grader" ]; then
     apt-get clean
     apt-get update
-    apt-get install -y pandoc texlive-xetex texlive-fonts-recommended texlive-generic-recommended build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev libgit2-dev texlive-lang-chinese
+    apt-get install -y pandoc texlive-xetex texlive-fonts-recommended texlive-generic-recommended build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev libgit2-dev texlive-lang-chinese libmagick++-dev
 
     # install wkhtmltopdf
     wget --quiet -O /tmp/wkhtmltopdf.deb https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.bionic_amd64.deb

--- a/test/test-assign/rmd-autograder-correct/setup.sh
+++ b/test/test-assign/rmd-autograder-correct/setup.sh
@@ -3,7 +3,8 @@
 if [ "${BASE_IMAGE}" != "ucbdsinfra/otter-grader" ]; then
     apt-get clean
     apt-get update
-    apt-get install -y pandoc texlive-xetex texlive-fonts-recommended texlive-generic-recommended build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev libgit2-dev texlive-lang-chinese libmagick++-dev
+    apt-get install -y pandoc texlive-xetex texlive-fonts-recommended texlive-generic-recommended build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev libgit2-dev texlive-lang-chinese
+    apt-get install -y libnlopt-dev cmake libfreetype6-dev libpng-dev libtiff5-dev libjpeg-dev apt-utils libpoppler-cpp-dev libavfilter-dev  libharfbuzz-dev libfribidi-dev imagemagick libmagick++-dev pandoc texlive-xetex texlive-fonts-recommended texlive-generic-recommended build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev libgit2-dev texlive-lang-chinese libxft-dev
 
     # install wkhtmltopdf
     wget --quiet -O /tmp/wkhtmltopdf.deb https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.bionic_amd64.deb

--- a/test/test-assign/rmd-autograder-correct/setup.sh
+++ b/test/test-assign/rmd-autograder-correct/setup.sh
@@ -3,7 +3,7 @@
 if [ "${BASE_IMAGE}" != "ucbdsinfra/otter-grader" ]; then
     apt-get clean
     apt-get update
-    apt-get install -y pandoc texlive-xetex texlive-fonts-recommended texlive-generic-recommended build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev libgit2-dev texlive-lang-chinese
+    apt-get install -y pandoc texlive-xetex texlive-fonts-recommended texlive-generic-recommended build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev libgit2-dev texlive-lang-chinese libmagick++-dev
 
     # install wkhtmltopdf
     wget --quiet -O /tmp/wkhtmltopdf.deb https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.bionic_amd64.deb

--- a/test/test_generate/test-autograder/autograder-r-correct/setup.sh
+++ b/test/test_generate/test-autograder/autograder-r-correct/setup.sh
@@ -3,7 +3,8 @@
 if [ "${BASE_IMAGE}" != "ucbdsinfra/otter-grader" ]; then
     apt-get clean
     apt-get update
-    apt-get install -y pandoc texlive-xetex texlive-fonts-recommended texlive-generic-recommended build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev libgit2-dev texlive-lang-chinese libmagick++-dev
+    apt-get install -y pandoc texlive-xetex texlive-fonts-recommended texlive-generic-recommended build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev libgit2-dev texlive-lang-chinese
+    apt-get install -y libnlopt-dev cmake libfreetype6-dev libpng-dev libtiff5-dev libjpeg-dev apt-utils libpoppler-cpp-dev libavfilter-dev  libharfbuzz-dev libfribidi-dev imagemagick libmagick++-dev pandoc texlive-xetex texlive-fonts-recommended texlive-generic-recommended build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev libgit2-dev texlive-lang-chinese libxft-dev
 
     # install wkhtmltopdf
     wget --quiet -O /tmp/wkhtmltopdf.deb https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.bionic_amd64.deb

--- a/test/test_generate/test-autograder/autograder-r-correct/setup.sh
+++ b/test/test_generate/test-autograder/autograder-r-correct/setup.sh
@@ -3,7 +3,7 @@
 if [ "${BASE_IMAGE}" != "ucbdsinfra/otter-grader" ]; then
     apt-get clean
     apt-get update
-    apt-get install -y pandoc texlive-xetex texlive-fonts-recommended texlive-generic-recommended build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev libgit2-dev texlive-lang-chinese
+    apt-get install -y pandoc texlive-xetex texlive-fonts-recommended texlive-generic-recommended build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev libgit2-dev texlive-lang-chinese libmagick++-dev
 
     # install wkhtmltopdf
     wget --quiet -O /tmp/wkhtmltopdf.deb https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.bionic_amd64.deb


### PR DESCRIPTION
Fixes a bug brought up in the Otter Slack: https://otter-grader.slack.com/archives/CT9QJK4PL/p1650581556482799?thread_ts=1649792498.203629&cid=CT9QJK4PL