### PR TITLE
Single Notebook Containerized Grading

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -166,7 +166,7 @@ The latter, the ``submission_pdfs`` directory, should contain the filtered PDFs 
 (which should be relatively similar).
 
 Otter Grade can also grade the zip file exports provided by the ``Notebook.export`` method. Before 
-grading the zip files, you must edit your ``autograder.zip`` to incdicate that you're doing so. To 
+grading the zip files, you must edit your ``autograder.zip`` to indicate that you're doing so. To 
 do this, open ``demo.ipynb`` (the file we used with Otter Assign) and edit the first cell of the 
 notebook (beginning with ``BEGIN ASSIGNMENT``) so that the ``zips`` key under ``generate`` is 
 ``true`` in the YAML and rerun Otter Assign.

--- a/docs/workflow/executing_submissions/otter_grade.rst
+++ b/docs/workflow/executing_submissions/otter_grade.rst
@@ -107,6 +107,17 @@ and at the end of grading we would have
         ├── q2.py
         └── q3.py    # etc.
 
+To grade a single notebook(as opposed to all the notebooks in a directory), you can pass the path to the
+notebook file using the flag ``-p``. For example, using the directory structure above, the call looks
+like this:
+
+.. code-block:: console
+
+    otter grade -p "./nb0.ipynb"
+
+The usual information for this graded notebook is written to ``final_grades.csv`` but the percent correct is returned
+to the command-line from the call as well.
+
 To grade submissions that aren't notebook files, use the ``--ext`` flag, which accepts the file 
 extension to search for submissions with. For example, if we had the same example as above but with 
 Rmd files:

--- a/otter/cli.py
+++ b/otter/cli.py
@@ -151,7 +151,10 @@ def grade_cli(*args, **kwargs):
     """
     Grade assignments locally using Docker containers.
     """
-    return grade(*args, **kwargs)
+    g = grade(*args, **kwargs)
+    if g is not None:
+        click.echo(g)
+    return g
 
 
 defaults = run.__kwdefaults__

--- a/otter/grade/__init__.py
+++ b/otter/grade/__init__.py
@@ -55,13 +55,12 @@ def main(*, path="./", output_dir="./", autograder="./autograder.zip", container
     temp_file_path = ""
     if os.path.isfile(path):
         single_file = True
-        ext = os.path.splitext(path)[1][1:] # remove the period from extension
+        ext = os.path.splitext(path)[1][1:]  # remove the period from extension
         file = os.path.split(path)[1]
-        temp_dir = tempfile.gettempdir()
+        temp_dir = tempfile.mkdtemp(prefix="otter_")
         temp_file_path = f"{temp_dir}/{file}"
         shutil.copy(path, temp_file_path)
         path = temp_dir
-
 
     # check file paths
     assert_path_exists([
@@ -99,5 +98,5 @@ def main(*, path="./", output_dir="./", autograder="./autograder.zip", container
     # write to CSV file
     output_df.to_csv(os.path.join(output_dir, "final_grades.csv"), index=False)
     if single_file:
-        os.remove(temp_file_path)
+        shutil.rmtree(temp_dir)
         return output_df["percent_correct"][0]

--- a/otter/grade/__init__.py
+++ b/otter/grade/__init__.py
@@ -48,12 +48,13 @@ def main(*, path="./", output_dir="./", autograder="./autograder.zip", container
 
     # if path leads to single file this indicates
     # the case and changes path to the directory
-    # Note: path will not be changed if the path
-    # is a directory and not a file
+    # as well as updates the ext argument
     single_file = False
-    if path.endswith(".ipynb"):
+    if os.path.isfile(path):
         single_file = True
-    path = os.path.dirname(path)
+        ext = os.path.splitext(path)[1][1:] # remove the period from extension
+        path = os.path.dirname(path)
+
     # check file paths
     assert_path_exists([
         (path, True),

--- a/otter/grade/__init__.py
+++ b/otter/grade/__init__.py
@@ -46,6 +46,14 @@ def main(*, path="./", output_dir="./", autograder="./autograder.zip", container
         prune_images(force=force)
         return
 
+    # if path leads to single file this indicates
+    # the case and changes path to the directory
+    # Note: path will not be changed if the path
+    # is a directory and not a file
+    single_file = False
+    if path.endswith(".ipynb"):
+        single_file = True
+    path = os.path.dirname(path)
     # check file paths
     assert_path_exists([
         (path, True),
@@ -81,3 +89,5 @@ def main(*, path="./", output_dir="./", autograder="./autograder.zip", container
 
     # write to CSV file
     output_df.to_csv(os.path.join(output_dir, "final_grades.csv"), index=False)
+    if single_file:
+        return output_df["percent_correct"][0]

--- a/otter/grade/__init__.py
+++ b/otter/grade/__init__.py
@@ -3,6 +3,8 @@
 import os
 import pandas as pd
 import re
+import shutil
+import tempfile
 
 from .containers import launch_grade
 from .utils import merge_csv, prune_images
@@ -50,10 +52,16 @@ def main(*, path="./", output_dir="./", autograder="./autograder.zip", container
     # the case and changes path to the directory
     # as well as updates the ext argument
     single_file = False
+    temp_file_path = ""
     if os.path.isfile(path):
         single_file = True
         ext = os.path.splitext(path)[1][1:] # remove the period from extension
-        path = os.path.dirname(path)
+        file = os.path.split(path)[1]
+        temp_dir = tempfile.gettempdir()
+        temp_file_path = f"{temp_dir}/{file}"
+        shutil.copy(path, temp_file_path)
+        path = temp_dir
+
 
     # check file paths
     assert_path_exists([
@@ -91,4 +99,5 @@ def main(*, path="./", output_dir="./", autograder="./autograder.zip", container
     # write to CSV file
     output_df.to_csv(os.path.join(output_dir, "final_grades.csv"), index=False)
     if single_file:
+        os.remove(temp_file_path)
         return output_df["percent_correct"][0]

--- a/otter/grade/containers.py
+++ b/otter/grade/containers.py
@@ -189,19 +189,12 @@ def grade_assignments(submission_path, image, no_kill=False, pdf_dir=None, pdfs=
         with open(results_path, "rb") as f:
             scores = pickle.load(f)
 
-        scores = scores.to_dict()
+        scores_dict = scores.to_dict()
+        scores_dict["percent_correct"] = scores.total / scores.possible
 
-        scores_to_process = list(filter(lambda key: type(scores[key]) == dict, scores))
-        possible_points = 0
-        raw_score = 0
-        for q in scores_to_process:
-            possible_points += scores[q]["possible"]
-            raw_score += scores[q]["score"]
-        scores["percent_correct"] = round(raw_score / possible_points, 4)
-
-        scores = {t: [scores[t]["score"]] if type(scores[t]) == dict else scores[t] for t in scores}
-        scores["file"] = os.path.split(submission_path)[1]
-        df = pd.DataFrame(scores)
+        scores_dict = {t: [scores_dict[t]["score"]] if type(scores_dict[t]) == dict else scores_dict[t] for t in scores_dict}
+        scores_dict["file"] = os.path.split(submission_path)[1]
+        df = pd.DataFrame(scores_dict)
 
         if pdfs:
             os.makedirs(pdf_dir, exist_ok=True)

--- a/otter/grade/containers.py
+++ b/otter/grade/containers.py
@@ -190,6 +190,15 @@ def grade_assignments(submission_path, image, no_kill=False, pdf_dir=None, pdfs=
             scores = pickle.load(f)
 
         scores = scores.to_dict()
+
+        scores_to_process = list(filter(lambda key: type(scores[key]) == dict, scores))
+        possible_points = 0
+        raw_score = 0
+        for q in scores_to_process:
+            possible_points += scores[q]["possible"]
+            raw_score += scores[q]["score"]
+        scores["percent_correct"] = round(raw_score / possible_points, 4)
+
         scores = {t: [scores[t]["score"]] if type(scores[t]) == dict else scores[t] for t in scores}
         scores["file"] = os.path.split(submission_path)[1]
         df = pd.DataFrame(scores)

--- a/test/test_grade.py
+++ b/test/test_grade.py
@@ -207,8 +207,7 @@ def test_notebooks_with_pdfs(expected_points):
     )
     assert sorted(dir1_contents) == sorted(dir2_contents), f"'{FILE_MANAGER.get_path('notebooks/')}' and 'test/submission_pdfs' have different contents"
 
-@pytest.mark.slow
-@pytest.mark.docker
+
 def test_single_notebook_grade(expected_points):
     """
     Check that single notebook passed to grade returns percent.
@@ -218,16 +217,16 @@ def test_single_notebook_grade(expected_points):
     df = pd.DataFrame(data)
     notebook_path = FILE_MANAGER.get_path("notebooks/passesAll.ipynb")
     kw_expected = {
-             "submissions_dir": mock.ANY, 
-             "num_containers": 1, 
-             "ext": 'ipynb', 
-             "no_kill":False, 
-             "output_path":'test/', 
-             "zips":False, 
-             "image":'otter-test', 
-             "pdfs":False, 
-             "timeout": None, 
-             "network": True
+        "submissions_dir": mock.ANY,
+        "num_containers": 1,
+        "ext": 'ipynb',
+        "no_kill": False,
+        "output_path": 'test/',
+        "zips": False,
+        "image": 'otter-test',
+        "pdfs": False,
+        "timeout": None,
+        "network": True
     }
 
     kws = {

--- a/test/test_grade.py
+++ b/test/test_grade.py
@@ -7,7 +7,7 @@ import pytest
 import re
 import shutil
 import subprocess
-import tempfile
+from unittest import mock
 import zipfile
 
 from glob import glob
@@ -213,17 +213,35 @@ def test_single_notebook_grade(expected_points):
     """
     Check that single notebook passed to grade returns percent.
     """
-    test_single_file_path = f"{tempfile.gettempdir()}/passesAll.ipynb"
-    shutil.copy(FILE_MANAGER.get_path("notebooks/passesAll.ipynb"), test_single_file_path)
-    # grade the single notebook
-    with loggers.level_context(logging.DEBUG):
-        output = grade(
-            path = test_single_file_path, 
-            output_dir = "test/",
-            autograder = FILE_MANAGER.get_path("autograder.zip"),
-            containers = 1,
-            image = "otter-test",
-            pdfs = False,
-        )
-        os.remove(test_single_file_path)
+    data =  [{'q1': 2.0, 'q2':2.0, 'q3':2.0, 'q4':1.0, 'q6':5.0, \
+                    'q2b':2.0, 'q7':1.0, 'percent_correct':1.0, 'file':'passesAll.ipynb'}]
+    df = pd.DataFrame(data)
+    notebook_path = FILE_MANAGER.get_path("notebooks/passesAll.ipynb")
+    expected_notebook_path_dir = os.path.dirname(notebook_path)
+    kw_expected = {
+             "submissions_dir": expected_notebook_path_dir, 
+             "num_containers": 1, 
+             "ext": 'ipynb', 
+             "no_kill":False, 
+             "output_path":'test/', 
+             "zips":False, 
+             "image":'otter-test', 
+             "pdfs":False, 
+             "timeout": None, 
+             "network": True
+    }
+
+    kws = {
+        "path": notebook_path, 
+        "output_dir": "test/",
+        "autograder": notebook_path,
+        "containers": 1,
+        "image" : "otter-test",
+        "pdfs" : False
+    }
+
+    with mock.patch("otter.grade.launch_grade") as mocked_launch_grade:
+        mocked_launch_grade.return_value = [df]
+        output = grade(**kws)
+        mocked_launch_grade.assert_called_with(notebook_path, **kw_expected)
         assert output == 1.0

--- a/test/test_grade.py
+++ b/test/test_grade.py
@@ -217,9 +217,8 @@ def test_single_notebook_grade(expected_points):
                     'q2b':2.0, 'q7':1.0, 'percent_correct':1.0, 'file':'passesAll.ipynb'}]
     df = pd.DataFrame(data)
     notebook_path = FILE_MANAGER.get_path("notebooks/passesAll.ipynb")
-    expected_notebook_path_dir = os.path.dirname(notebook_path)
     kw_expected = {
-             "submissions_dir": expected_notebook_path_dir, 
+             "submissions_dir": mock.ANY, 
              "num_containers": 1, 
              "ext": 'ipynb', 
              "no_kill":False, 


### PR DESCRIPTION
This PR derives from the [PR](https://github.com/ucbds-infra/otter-grader/pull/487) I submitted on the master branch before I knew about the beta branch!  

- I added a pytest to verify single notebook grading
- made single notebook grading possible for all types of notebooks
- used the instance state of the scores field(GradingResults object) to calculate the percentage correct