### PR TITLE
Close file handles in otter check zip validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+**v4.0.2:**
+
+* Closed temporary file handle before removal when checking tests in `otter.Notebook.export`
+
 **v4.0.1:**
 
 * Fix Otter Grade Dockerfile per [#517](https://github.com/ucbds-infra/otter-grader/issues/517)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **v4.0.2:**
 
-* Closed temporary file handle before removal when checking tests in `otter.Notebook.export`
+* Close temporary file handle before removal when checking tests in `otter.Notebook.export`
 
 **v4.0.1:**
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,5 +52,5 @@ RUN mkdir /autograder
 ADD requirements.txt /tmp/requirements.txt
 RUN pip install -r /tmp/requirements.txt
 
-RUN pip install otter-grader==4.0.1
+RUN pip install git+https://github.com/ucbds-infra/otter-grader.git@719e993793d8d16a24b899b1c3b0ea8d0d43beff
 RUN Rscript -e "install.packages('ottr', dependencies=TRUE, repos='http://cran.us.r-project.org')"

--- a/otter/check/utils.py
+++ b/otter/check/utils.py
@@ -74,6 +74,10 @@ def grade_zip_file(zip_path, nb_arcname, tests_dir):
         # run the command
         results = run(command, stdout=PIPE, stderr=PIPE)
 
+        # TODO: remove
+        print(results.stdout.decode("utf-8"))
+        print(results.stderr.decode("utf-8"))
+
         if results.stderr:
             raise RuntimeError(results.stderr)
 

--- a/otter/check/utils.py
+++ b/otter/check/utils.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import os
 import requests
+import sys
 import tempfile
 import time
 import wrapt
@@ -64,7 +65,7 @@ def grade_zip_file(zip_path, nb_arcname, tests_dir):
 
     try:
         command = [
-            "python3", "-m", "otter.check.validate_export",
+            sys.executable, "-m", "otter.check.validate_export",
             "--zip-path", zip_path,
             "--nb-arcname", nb_arcname,
             "--tests-dir", tests_dir,

--- a/otter/check/utils.py
+++ b/otter/check/utils.py
@@ -60,7 +60,7 @@ def grade_zip_file(zip_path, nb_arcname, tests_dir):
     """
     dill = import_or_raise("dill")
 
-    _, results_path = tempfile.mkstemp(suffix=".pkl")
+    results_handle, results_path = tempfile.mkstemp(suffix=".pkl")
 
     try:
         command = [
@@ -83,6 +83,7 @@ def grade_zip_file(zip_path, nb_arcname, tests_dir):
         return results
 
     finally:
+        os.close(results_handle)
         os.remove(results_path)
 
 

--- a/otter/generate/templates/python/requirements.txt
+++ b/otter/generate/templates/python/requirements.txt
@@ -12,6 +12,6 @@ nbconvert
 nbformat
 dill
 numpy
-otter-grader==4.0.1
+git+https://github.com/ucbds-infra/otter-grader.git@719e993793d8d16a24b899b1c3b0ea8d0d43beff
 {% endif %}{% if other_requirements %}
 {{ other_requirements }}{% endif %}

--- a/otter/generate/templates/r/requirements.txt
+++ b/otter/generate/templates/r/requirements.txt
@@ -13,4 +13,4 @@ nbformat
 dill
 rpy2
 numpy
-otter-grader==4.0.1
+git+https://github.com/ucbds-infra/otter-grader.git@719e993793d8d16a24b899b1c3b0ea8d0d43beff

--- a/test/test-assign/example-autograder-correct/requirements.txt
+++ b/test/test-assign/example-autograder-correct/requirements.txt
@@ -12,4 +12,4 @@ nbconvert
 nbformat
 dill
 numpy
-otter-grader==4.0.1
+git+https://github.com/ucbds-infra/otter-grader.git@719e993793d8d16a24b899b1c3b0ea8d0d43beff

--- a/test/test-assign/gs-autograder-correct/requirements.txt
+++ b/test/test-assign/gs-autograder-correct/requirements.txt
@@ -12,4 +12,4 @@ nbconvert
 nbformat
 dill
 numpy
-otter-grader==4.0.1
+git+https://github.com/ucbds-infra/otter-grader.git@719e993793d8d16a24b899b1c3b0ea8d0d43beff

--- a/test/test-assign/rmd-autograder-correct/requirements.txt
+++ b/test/test-assign/rmd-autograder-correct/requirements.txt
@@ -13,4 +13,4 @@ nbformat
 dill
 rpy2
 numpy
-otter-grader==4.0.1
+git+https://github.com/ucbds-infra/otter-grader.git@719e993793d8d16a24b899b1c3b0ea8d0d43beff

--- a/test/test-run/autograder/source/requirements.txt
+++ b/test/test-run/autograder/source/requirements.txt
@@ -12,6 +12,6 @@ nbconvert
 nbformat
 dill
 numpy
-otter-grader==4.0.1
+git+https://github.com/ucbds-infra/otter-grader.git@719e993793d8d16a24b899b1c3b0ea8d0d43beff
 
 tqdm

--- a/test/test_generate/test-autograder/autograder-correct/requirements.txt
+++ b/test/test_generate/test-autograder/autograder-correct/requirements.txt
@@ -12,6 +12,6 @@ nbconvert
 nbformat
 dill
 numpy
-otter-grader==4.0.1
+git+https://github.com/ucbds-infra/otter-grader.git@719e993793d8d16a24b899b1c3b0ea8d0d43beff
 
 tqdm

--- a/test/test_generate/test-autograder/autograder-custom-env/requirements.txt
+++ b/test/test_generate/test-autograder/autograder-custom-env/requirements.txt
@@ -12,6 +12,6 @@ nbconvert
 nbformat
 dill
 numpy
-otter-grader==4.0.1
+git+https://github.com/ucbds-infra/otter-grader.git@719e993793d8d16a24b899b1c3b0ea8d0d43beff
 
 tqdm

--- a/test/test_generate/test-autograder/autograder-r-correct/requirements.txt
+++ b/test/test_generate/test-autograder/autograder-r-correct/requirements.txt
@@ -13,4 +13,4 @@ nbformat
 dill
 rpy2
 numpy
-otter-grader==4.0.1
+git+https://github.com/ucbds-infra/otter-grader.git@719e993793d8d16a24b899b1c3b0ea8d0d43beff

--- a/test/test_generate/test-autograder/autograder-token-correct/requirements.txt
+++ b/test/test_generate/test-autograder/autograder-token-correct/requirements.txt
@@ -12,6 +12,6 @@ nbconvert
 nbformat
 dill
 numpy
-otter-grader==4.0.1
+git+https://github.com/ucbds-infra/otter-grader.git@719e993793d8d16a24b899b1c3b0ea8d0d43beff
 
 tqdm


### PR DESCRIPTION
Fixes a bug from [Slack](https://otter-grader.slack.com/archives/CT9QJK4PL/p1661892005654379) similar to #389.

> We are running into PermissionError when we try to run the student version of the notebook file only on Windows platform. The same notebook file is working on MAC platform. Can you please tell us what we are missing here? I have attached a zip file of the entire directory, including the master notebook file and the student directory with the error.<br><br>
Error details:

```
Running your submission against local test cases...

---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
File ~\anaconda3\lib\site-packages\otter\check\utils.py:78, in grade_zip_file(zip_path, nb_arcname, tests_dir)
     77 if results.stderr:
---> 78     raise RuntimeError(results.stderr)
     80 with open(results_path, "rb") as f:

RuntimeError: b'Python was not found; run without arguments to install from the Microsoft Store, or disable this shortcut from Settings > Manage App Execution Aliases.\r\n'

During handling of the above exception, another exception occurred:

PermissionError                           Traceback (most recent call last)
Input In [7], in <cell line: 2>()
      1 # Save your notebook first, then run this cell to export your submission.
----> 2 grader.export(pdf=False, run_tests=True)

File ~\anaconda3\lib\site-packages\otter\check\utils.py:151, in grading_mode_disabled(wrapped, self, args, kwargs)
    149 if type(self)._grading_mode:
    150     return
--> 151 return wrapped(*args, **kwargs)

File ~\anaconda3\lib\site-packages\otter\check\utils.py:138, in incompatible_with.<locals>.incompatible(wrapped, self, args, kwargs)
    136     else:
    137         return
--> 138 return wrapped(*args, **kwargs)

File ~\anaconda3\lib\site-packages\otter\check\utils.py:188, in logs_event.<locals>.event_logger(wrapped, self, args, kwargs)
    186 except Exception as e:
    187     self._log_event(event_type, success=False, error=e)
--> 188     raise e
    190 else:
    191     self._log_event(event_type, results=results, question=question, shelve_env=shelve_env)

File ~\anaconda3\lib\site-packages\otter\check\utils.py:182, in logs_event.<locals>.event_logger(wrapped, self, args, kwargs)
    179     question, results, shelve_env = wrapped(*args, **kwargs)
    181 else:
--> 182     results = wrapped(*args, **kwargs)
    183     shelve_env = {}
    184     question = None

File ~\anaconda3\lib\site-packages\otter\check\notebook.py:415, in Notebook.export(self, nb_path, export_path, pdf, filtering, pagebreaks, files, display_link, force_save, run_tests)
    413 if run_tests:
    414     print("Running your submission against local test cases...\n")
--> 415     results = grade_zip_file(zip_path, nb_path, self._path)
    416     print(
    417         "Your submission received the following results when run against " + \
    418         "available test cases:\n\n" + indent(results.summary(), "    "))
    420 if display_link:
    421     # create and display output HTML

File ~\anaconda3\lib\site-packages\otter\check\utils.py:86, in grade_zip_file(zip_path, nb_arcname, tests_dir)
     83     return results
     85 finally:
---> 86     os.remove(results_path)

PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\user\\AppData\\Local\\Temp\\tmpg3gsknc3.pkl'
```