### PR TITLE
Add ipython as an explicit requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ wrapt
 jupytext
 click
 fica>=0.2.0
+ipython
 
 # plugins
 google-api-python-client


### PR DESCRIPTION
otter-grader will fail to import without it, see
https://github.com/conda-forge/staged-recipes/pull/20953#issuecomment-1301101460