### PR TITLE
GradeOverride Plugin

### DIFF
--- a/otter/plugins/builtin/grade_override.py
+++ b/otter/plugins/builtin/grade_override.py
@@ -115,7 +115,7 @@ class GoogleSheetsGradeOverride(AbstractOtterPlugin):
         with open(creds_path, encoding="utf-8") as f:
             creds = json.load(f)
         plugins[cfg_idx][self.IMPORTABLE_NAME]["service_account_credentials"] = creds
-
+        otter_config["plugins"] = plugins
         if assignment is not None:
             os.chdir(curr_dir)
 


### PR DESCRIPTION
In the case where the plugins are stored on the assignment and not in otter_config, we need to set
otter_config["plugins"] with the plugins attribute from the assignment.