### PR TITLE
Fix #686 (Grader Export Cell Fails)

### DIFF
--- a/otter/check/utils.py
+++ b/otter/check/utils.py
@@ -71,8 +71,11 @@ def grade_zip_file(zip_path, nb_arcname, tests_dir):
             "--results-path", results_path,
         ]
 
+        # this environment variable is needed to fix #686
+        subprocess_env = {**os.environ, "PYDEVD_DISABLE_FILE_VALIDATION": "1"}
+
         # run the command
-        results = run(command, stdout=PIPE, stderr=PIPE)
+        results = run(command, env=subprocess_env, stdout=PIPE, stderr=PIPE)
 
         # TODO: remove
         print(results.stdout.decode("utf-8"))


### PR DESCRIPTION
This PR fixes #686. It feels kind of hacky, so I'm not sure if it's the correct way to fix the issue. I also tried passing the `-Xfrozen_modules=off` argument, but this doesn't solve the issue. Instead, the `stderr` output of the process changes from

```
0.00s - Debugger warning: It seems that frozen modules are being used, which may
0.00s - make the debugger miss breakpoints. Please pass -Xfrozen_modules=off
0.00s - to python to disable frozen modules.
0.00s - Note: Debugging will proceed. Set PYDEVD_DISABLE_FILE_VALIDATION=1 to disable this validation.
0.00s - Debugger warning: It seems that frozen modules are being used, which may
0.00s - make the debugger miss breakpoints. Please pass -Xfrozen_modules=off
0.00s - to python to disable frozen modules.
0.00s - Note: Debugging will proceed. Set PYDEVD_DISABLE_FILE_VALIDATION=1 to disable this validation.
```

to

```
0.00s - Debugger warning: It seems that frozen modules are being used, which may
0.00s - make the debugger miss breakpoints. Please pass -Xfrozen_modules=off
0.00s - to python to disable frozen modules.
0.00s - Note: Debugging will proceed. Set PYDEVD_DISABLE_FILE_VALIDATION=1 to disable this validation.
```

I presume that the subprocess starts *another* subprocess (without using the `-Xfrozen_modules=off` flag) which triggers the successive warning. By starting the former subprocess with the `PYDEVD_DISABLE_FILE_VALIDATION=1` environment variable, the latter subprocess inherits it and suppresses the second warning.