### PR TITLE
Fix recursive inclusion of files when a directory is in the list passed to the `files` argument of `Notebook.export`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Added notebook force-save to R notebook assignments per [#474](https://github.com/ucbds-infra/otter-grader/issues/474)
 * Updated default version of `ottr` to v1.4.0
 * Added a configuration to require students to acknowledge when a PDF of their notebook cannot be generated when using `Notebook.export` before exporting the zip file per [#599](https://github.com/ucbds-infra/otter-grader/issues/599)
+* Fixed recursive inclusion of files when a directory is in the list passed to the `files` argument of `Notebook.export` per [#620](https://github.com/ucbds-infra/otter-grader/issues/620)
 
 **v5.0.2:**
 

--- a/otter/check/notebook.py
+++ b/otter/check/notebook.py
@@ -411,7 +411,7 @@ class Notebook(Loggable):
 
             for file in files:
                 if os.path.isdir(file):
-                    sub_files = glob(f"./{file}/**/*.*")
+                    sub_files = glob(f"{file}/**/*.*", recursive=True)
                     for sub_file in sub_files:
                         zf.write(sub_file)
                 else:

--- a/test/test_check/test_notebook.py
+++ b/test/test_check/test_notebook.py
@@ -4,6 +4,7 @@ import datetime as dt
 import nbformat as nbf
 import os
 import pytest
+import shutil
 
 from glob import glob
 from textwrap import dedent
@@ -158,6 +159,33 @@ def test_export(mocked_export, mocked_zf, mocked_dt, write_notebook):
     # TODO: test force_save
     # TODO: test run_tests
     # TODO: test display_link
+
+
+@mock.patch("otter.check.notebook.zipfile.ZipFile")
+def test_export_with_directory_in_files(mocked_zf, write_notebook):
+    """
+    Checks that ``Notebook.export`` correctly recurses into subdirectories to find files when a
+    directory is in the list passed to the ``files`` argument.
+    """
+    write_notebook(nbf.v4.new_notebook())
+
+    file_path = FILE_MANAGER.get_path("data/foo.csv")
+    dir_path = os.path.split(file_path)[0]
+    os.makedirs(dir_path, exist_ok=True)
+    with open(file_path, "w+") as f:
+        f.write("hi there")
+
+    try:
+        grader = Notebook(tests_dir=TESTS_DIR)
+        with mock.patch.object(grader, "_resolve_nb_path") as mocked_resolve:
+            mocked_resolve.return_value = NB_PATH
+
+            grader.export(pdf=False, files=[dir_path])
+
+            mocked_zf.return_value.write.assert_any_call(file_path)
+
+    finally:
+        shutil.rmtree(dir_path)
 
 
 @mock.patch("otter.check.utils.Button")


### PR DESCRIPTION
Closes #620