### PR TITLE
 Adds __getstate__ to test_case for exception_tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **v5.1.1 (unreleased):**
 
 * Fixed a bug in attempting to read the users from the submission metadata when validating the autograder notebook in Otter Assign per [#695](https://github.com/ucbds-infra/otter-grader/issues/695)
+* Added `__getstate__` to `test_case` to fix pickling bug for exception style tests per [#696](https://github.com/ucbds-infra/otter-grader/issues/696)
 
 **v5.1.0:**
 

--- a/otter/test_files/exception_test.py
+++ b/otter/test_files/exception_test.py
@@ -97,6 +97,20 @@ class test_case:
         call_kwargs = {arg: (global_environment if arg == "env" else \
                 global_environment.get(arg, None)) for arg in args}
         return self.test_func(**call_kwargs)
+    
+    def __getstate__(self):
+        """
+        Creates a representation of the state of the instance. The attributes of the object are 
+        packaged into a dictionary representation excluding certain attributes. ``test_func`` is 
+        excluded because it cannot be pickled.
+
+        Returns:
+            ``dict``: a dictionary representation of the instance's state
+        """
+        state = self.__dict__.copy()
+        if 'test_func' in state:
+            del state['test_func']
+        return state
 
 
 class ExceptionTestFile(TestFile):


### PR DESCRIPTION
Previously, otter would fail due to PicklingError for exception style tests. This gets rid of test_func from the pickling state because it cannot be pickled.

Fixes https://github.com/ucbds-infra/otter-grader/issues/696.

This is a copy of #698 off of master instead of beta.