### PR TITLE
Fix Catastrophic EOF

### DIFF
--- a/otter/execute/__init__.py
+++ b/otter/execute/__init__.py
@@ -100,8 +100,15 @@ def grade_notebook(
             stop_server()
             gp.cleanup()
 
-        results = pickle.load(ntf)
-
+        try:
+            results = pickle.load(ntf)
+        except EOFError:
+            import sys
+            print(sys.executable)
+            import pprint
+            pprint.pprint(executed_nb)
+            raise
+            
     if not isinstance(results, GradingResults):
         raise TypeError("Results deserialized from grading notebook were not a GradingResults instance")
 


### PR DESCRIPTION
**Untested** (`make test` fails on master on my Win11 machine)... just picked the logic that was present in 4.4.1 (working version) prior to the cleanup.