### PR TITLE
Update Otter Grade to sort grades CSV by filename

### DIFF
--- a/otter/grade/containers.py
+++ b/otter/grade/containers.py
@@ -221,7 +221,7 @@ def grade_submission(
         scores_dict["percent_correct"] = scores.total / scores.possible
 
         scores_dict = {t: [scores_dict[t]["score"]] if type(scores_dict[t]) == dict else scores_dict[t] for t in scores_dict}
-        scores_dict["file"] = submission_path
+        scores_dict["file"] = nb_basename
         df = pd.DataFrame(scores_dict)
 
         if pdf_dir:

--- a/otter/grade/utils.py
+++ b/otter/grade/utils.py
@@ -35,7 +35,7 @@ def merge_csv(dataframes):
         ``pandas.core.frame.DataFrame``: A merged dataframe resulting from 'stacking' all input dataframes
 
     """
-    final_dataframe = pd.concat(dataframes, axis=0, join='inner').sort_index()
+    final_dataframe = pd.concat(dataframes, axis=0, join='inner').sort_index().sort_values(by="file")
     return final_dataframe
 
 


### PR DESCRIPTION
- Sorted notebooks by name
- Removed path from file name in final_grades.csv (e.g. notebooks/A.ipynb now is A.ipynb)