### PR TITLE
Fix tests using np.isclose due to new numpy bool dtype

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ PYTESTOPTS       =
 COVERAGE         = coverage
 DOCKER           = true
 SLOW             = true
+CLEANUP          = true
 
 _PYTESTOPTS      := -vv --durations=0 --html=pytest-report.html --self-contained-html
 
@@ -13,6 +14,10 @@ endif
 
 ifeq ($(SLOW), false)
 	_PYTESTOPTS := $(_PYTESTOPTS) -m "not slow"
+endif
+
+ifeq ($(CLEANUP), false)
+	_PYTESTOPTS := $(_PYTESTOPTS) --nocleanup
 endif
 
 _PYTESTOPTS := $(_PYTESTOPTS) $(PYTESTOPTS)

--- a/test/test_check/files/logs-tests/q4.py
+++ b/test/test_check/files/logs-tests/q4.py
@@ -10,7 +10,7 @@ test = {
 				{
 					"code": r"""
 					>>> np.isclose(x, 39.0625)
-					True
+					np.True_
 					""",
 					"hidden": True,
 					"locked": False,

--- a/test/test_generate/files/autograder-correct/tests/q4.py
+++ b/test/test_generate/files/autograder-correct/tests/q4.py
@@ -8,7 +8,7 @@ test = {
 				{
 					"code": r"""
 					>>> np.isclose(x, 39.0625)
-					True
+					np.True_
 					""",
 					"hidden": True,
 					"locked": False,

--- a/test/test_generate/files/autograder-custom-env/tests/q4.py
+++ b/test/test_generate/files/autograder-custom-env/tests/q4.py
@@ -8,7 +8,7 @@ test = {
 				{
 					"code": r"""
 					>>> np.isclose(x, 39.0625)
-					True
+					np.True_
 					""",
 					"hidden": True,
 					"locked": False,

--- a/test/test_generate/files/autograder-token-correct/tests/q4.py
+++ b/test/test_generate/files/autograder-token-correct/tests/q4.py
@@ -8,7 +8,7 @@ test = {
 				{
 					"code": r"""
 					>>> np.isclose(x, 39.0625)
-					True
+					np.True_
 					""",
 					"hidden": True,
 					"locked": False,

--- a/test/test_generate/files/tests/q4.py
+++ b/test/test_generate/files/tests/q4.py
@@ -8,7 +8,7 @@ test = {
 				{
 					"code": r"""
 					>>> np.isclose(x, 39.0625)
-					True
+					np.True_
 					""",
 					"hidden": True,
 					"locked": False,

--- a/test/test_grade/files/tests/q4.py
+++ b/test/test_grade/files/tests/q4.py
@@ -10,7 +10,7 @@ test = {
 				{
 					"code": r"""
 					>>> np.isclose(x, 39.0625)
-					True
+					np.True_
 					""",
 					"hidden": True,
 					"locked": False,

--- a/test/test_run/files/autograder/source/tests/q4.py
+++ b/test/test_run/files/autograder/source/tests/q4.py
@@ -10,7 +10,7 @@ test = {
 				{
 					"code": r"""
 					>>> np.isclose(x, 39.0625)
-					True
+					np.True_
 					""",
 					"hidden": True,
 					"locked": False,
@@ -18,7 +18,7 @@ test = {
 				{
 					"code": r"""
 					>>> np.isclose(x, 39.0625)
-					True
+					np.True_
 					""",
 					"hidden": True,
 					"locked": False,
@@ -26,7 +26,7 @@ test = {
 				{
 					"code": r"""
 					>>> np.isclose(x, 39.0625)
-					True
+					np.True_
 					""",
 					"hidden": True,
 					"locked": False,
@@ -34,7 +34,7 @@ test = {
 				{
 					"code": r"""
 					>>> np.isclose(x, 39.0625)
-					True
+					np.True_
 					""",
 					"hidden": True,
 					"locked": False,
@@ -42,7 +42,7 @@ test = {
 				{
 					"code": r"""
 					>>> np.isclose(x, 39.0625)
-					True
+					np.True_
 					""",
 					"hidden": True,
 					"locked": False,
@@ -50,7 +50,7 @@ test = {
 				{
 					"code": r"""
 					>>> np.isclose(x, 39.0625)
-					True
+					np.True_
 					""",
 					"hidden": True,
 					"locked": False,
@@ -58,7 +58,7 @@ test = {
 				{
 					"code": r"""
 					>>> np.isclose(x, 39.0625)
-					True
+					np.True_
 					""",
 					"hidden": True,
 					"locked": False,


### PR DESCRIPTION
numpy v2.0.0 started causing test cases that passed previously to start failing with

```
    ❌ Test case failed
    Trying:
        np.isclose(x, 39.0625)
    Expecting:
        True
    **********************************************************************
    Line 2, in q4 0
    Failed example:
        np.isclose(x, 39.0625)
    Expected:
        True
    Got:
        np.True_
```