### PR TITLE
Otter Grade Timeout Updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **v5.6.0 (unreleased):**
 
-* Updated Otter Grade CSV to indicate which notebooks timeout [#813](https://github.com/ucbds-infra/otter-grader/issues/813)
+* Updated Otter Grade CSV to indicate which notebooks timeout per [#813](https://github.com/ucbds-infra/otter-grader/issues/813)
 * Updated Otter Grade CSV to include the number of points per question in the first row
 * Updated Otter Grade CSV to include total points column
 * Updated Otter Grade CSV to round percentages to four decimal places

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 **v5.6.0 (unreleased):**
 
+* Updated Otter Grade CAV to indicate which notebooks timeout
 * Updated Otter Grade CSV to include the number of points per question in the first row
 * Updated Otter Grade CSV to include total points column
 * Updated Otter Grade CSV to round percentages to four decimal places

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **v5.6.0 (unreleased):**
 
-* Updated Otter Grade CAV to indicate which notebooks timeout
+* Updated Otter Grade CSV to indicate which notebooks timeout [#813](https://github.com/ucbds-infra/otter-grader/issues/813)
 * Updated Otter Grade CSV to include the number of points per question in the first row
 * Updated Otter Grade CSV to include total points column
 * Updated Otter Grade CSV to round percentages to four decimal places

--- a/otter/grade/__init__.py
+++ b/otter/grade/__init__.py
@@ -16,6 +16,7 @@ from .utils import (
     SCORES_DICT_GRADING_STATUS_KEY,
     SCORES_DICT_SUMMARY_KEY
 )
+
 from ..run.run_autograder.autograder_config import AutograderConfig
 from ..utils import assert_path_exists, loggers
 
@@ -152,7 +153,7 @@ def main(
     ]]
 
     # write to CSV file
-    output_df.to_csv(os.path.join(output_dir, "final_grades.csv"), na_rep='--', index=False)
+    output_df.to_csv(os.path.join(output_dir, "final_grades.csv"), index=False)
 
     # return percentage if a single file was graded
     if len(paths) == 1 and os.path.isfile(paths[0]):

--- a/otter/grade/__init__.py
+++ b/otter/grade/__init__.py
@@ -7,7 +7,9 @@ from glob import glob
 from typing import List, Optional, Tuple, Union
 
 from .containers import launch_containers
-from .utils import merge_csv, prune_images, SCORES_DICT_FILE_KEY, SCORES_DICT_PERCENT_CORRECT_KEY,  SCORES_DICT_TOTAL_POINTS_KEY
+from .utils import merge_csv, prune_images, \
+                    SCORES_DICT_FILE_KEY, SCORES_DICT_PERCENT_CORRECT_KEY,  SCORES_DICT_TOTAL_POINTS_KEY, \
+                    SCORES_DICT_GRADING_STATUS_KEY, SCORES_DICT_SUMMARY_KEY
 
 from ..run.run_autograder.autograder_config import AutograderConfig
 from ..utils import assert_path_exists, loggers
@@ -129,8 +131,8 @@ def main(
     # Merge dataframes
     output_df = merge_csv(grade_dfs)
     cols = output_df.columns.tolist()
-    question_cols = sorted(c for c in cols if c not in {SCORES_DICT_FILE_KEY, SCORES_DICT_TOTAL_POINTS_KEY, SCORES_DICT_PERCENT_CORRECT_KEY})
-    output_df = output_df[[SCORES_DICT_FILE_KEY, *question_cols, SCORES_DICT_TOTAL_POINTS_KEY, SCORES_DICT_PERCENT_CORRECT_KEY]]  
+    question_cols = sorted(c for c in cols if c not in {SCORES_DICT_FILE_KEY, SCORES_DICT_TOTAL_POINTS_KEY, SCORES_DICT_PERCENT_CORRECT_KEY, SCORES_DICT_GRADING_STATUS_KEY, SCORES_DICT_SUMMARY_KEY})
+    output_df = output_df[[SCORES_DICT_FILE_KEY, *question_cols, SCORES_DICT_TOTAL_POINTS_KEY, SCORES_DICT_PERCENT_CORRECT_KEY, SCORES_DICT_GRADING_STATUS_KEY]]
 
     # write to CSV file
     output_df.to_csv(os.path.join(output_dir, "final_grades.csv"), index=False)

--- a/otter/grade/__init__.py
+++ b/otter/grade/__init__.py
@@ -152,7 +152,7 @@ def main(
     ]]
 
     # write to CSV file
-    output_df.to_csv(os.path.join(output_dir, "final_grades.csv"), index=False)
+    output_df.to_csv(os.path.join(output_dir, "final_grades.csv"), na_rep='--', index=False)
 
     # return percentage if a single file was graded
     if len(paths) == 1 and os.path.isfile(paths[0]):

--- a/otter/grade/__init__.py
+++ b/otter/grade/__init__.py
@@ -7,10 +7,15 @@ from glob import glob
 from typing import List, Optional, Tuple, Union
 
 from .containers import launch_containers
-from .utils import merge_csv, prune_images, \
-                    SCORES_DICT_FILE_KEY, SCORES_DICT_PERCENT_CORRECT_KEY,  SCORES_DICT_TOTAL_POINTS_KEY, \
-                    SCORES_DICT_GRADING_STATUS_KEY, SCORES_DICT_SUMMARY_KEY
-
+from .utils import (
+    merge_csv,
+    prune_images,
+    SCORES_DICT_FILE_KEY,
+    SCORES_DICT_PERCENT_CORRECT_KEY,
+    SCORES_DICT_TOTAL_POINTS_KEY,
+    SCORES_DICT_GRADING_STATUS_KEY,
+    SCORES_DICT_SUMMARY_KEY
+)
 from ..run.run_autograder.autograder_config import AutograderConfig
 from ..utils import assert_path_exists, loggers
 
@@ -131,8 +136,20 @@ def main(
     # Merge dataframes
     output_df = merge_csv(grade_dfs)
     cols = output_df.columns.tolist()
-    question_cols = sorted(c for c in cols if c not in {SCORES_DICT_FILE_KEY, SCORES_DICT_TOTAL_POINTS_KEY, SCORES_DICT_PERCENT_CORRECT_KEY, SCORES_DICT_GRADING_STATUS_KEY, SCORES_DICT_SUMMARY_KEY})
-    output_df = output_df[[SCORES_DICT_FILE_KEY, *question_cols, SCORES_DICT_TOTAL_POINTS_KEY, SCORES_DICT_PERCENT_CORRECT_KEY, SCORES_DICT_GRADING_STATUS_KEY]]
+    question_cols = sorted(c for c in cols if c not in {
+        SCORES_DICT_FILE_KEY,
+        SCORES_DICT_TOTAL_POINTS_KEY,
+        SCORES_DICT_PERCENT_CORRECT_KEY,
+        SCORES_DICT_GRADING_STATUS_KEY,
+        SCORES_DICT_SUMMARY_KEY
+    })
+    output_df = output_df[[
+        SCORES_DICT_FILE_KEY,
+        *question_cols,
+        SCORES_DICT_TOTAL_POINTS_KEY,
+        SCORES_DICT_PERCENT_CORRECT_KEY,
+        SCORES_DICT_GRADING_STATUS_KEY
+    ]]
 
     # write to CSV file
     output_df.to_csv(os.path.join(output_dir, "final_grades.csv"), index=False)

--- a/otter/grade/containers.py
+++ b/otter/grade/containers.py
@@ -14,17 +14,13 @@ from python_on_whales import docker
 from textwrap import indent
 from typing import List, Optional
 
-from .utils import OTTER_DOCKER_IMAGE_NAME, merge_scores_to_df
+from .utils import OTTER_DOCKER_IMAGE_NAME, merge_scores_to_df, TimeoutException
 
 from ..run.run_autograder.autograder_config import AutograderConfig
 from ..utils import loggers, OTTER_CONFIG_FILENAME
 
 
 LOGGER = loggers.get_logger(__name__)
-
-
-class TimeoutException(Exception):
-    pass
 
 
 def build_image(ag_zip_path: str, base_image: str, tag: str, config: AutograderConfig):
@@ -135,6 +131,10 @@ def grade_submission(
 ):
     """
     Grade a submission in a Docker container.
+
+    If a sumbission times out, based on the timeout parameter or the container
+    exits in an error state a ``GradingResults`` object is created by using the
+    ``GradingResults.without_results`` function and returned.
 
     Args:
         submission_path (``str``): path to the submission to be graded

--- a/otter/grade/containers.py
+++ b/otter/grade/containers.py
@@ -7,7 +7,6 @@ import pkg_resources
 import shutil
 import tempfile
 import zipfile
-from ..test_files import GradingResults
 
 from concurrent.futures import ThreadPoolExecutor, wait
 from python_on_whales import docker
@@ -17,6 +16,7 @@ from typing import List, Optional
 from .utils import OTTER_DOCKER_IMAGE_NAME, merge_scores_to_df, TimeoutException
 
 from ..run.run_autograder.autograder_config import AutograderConfig
+from ..test_files import GradingResults
 from ..utils import loggers, OTTER_CONFIG_FILENAME
 
 

--- a/otter/grade/containers.py
+++ b/otter/grade/containers.py
@@ -146,7 +146,7 @@ def grade_submission(
         network (``bool``): whether to enable networking in the containers
 
     Returns:
-        ``pandas.core.frame.DataFrame``: A dataframe of file to grades information
+        ``otter.test_files.GradingResults``: A ``GradingResults`` object containing the grading results
     """
     import dill
 

--- a/otter/grade/containers.py
+++ b/otter/grade/containers.py
@@ -7,7 +7,7 @@ import pkg_resources
 import shutil
 import tempfile
 import zipfile
-from otter.test_files import GradingResults
+from ..test_files import GradingResults
 
 from concurrent.futures import ThreadPoolExecutor, wait
 from python_on_whales import docker

--- a/otter/grade/utils.py
+++ b/otter/grade/utils.py
@@ -101,7 +101,7 @@ def get_points_possible_df(scores: List[GradingResults]) -> pd.DataFrame:
     if gr_completed:
         pts_poss_dict = {t: [gr_completed[0].to_dict()[t]["possible"]] for t in gr_completed[0].to_dict()}
         pts_poss_dict[SCORES_DICT_FILE_KEY] = POINTS_POSSIBLE_LABEL
-        pts_poss_dict[SCORES_DICT_PERCENT_CORRECT_KEY] = "--"
+        pts_poss_dict[SCORES_DICT_PERCENT_CORRECT_KEY] = "NA"
         pts_poss_dict[SCORES_DICT_TOTAL_POINTS_KEY] = gr_completed[0].possible
         pts_poss_dict[SCORES_DICT_SUMMARY_KEY] = "--"
         pts_poss_dict[SCORES_DICT_GRADING_STATUS_KEY] = "--"
@@ -128,13 +128,13 @@ def merge_scores_to_df(scores: List[GradingResults]) -> pd.DataFrame:
         scores_dict = gr.to_dict()
         failed = gr.has_catastrophic_failure()
         if failed and not pts_poss_df.empty:
-            scores_dict = {t: ["--"] for t in pts_poss_df.to_dict()}
+            scores_dict = {t: ["NA"] for t in pts_poss_df.to_dict()}
         elif not failed:
             scores_dict = {t: [scores_dict[t]["score"]] for t in scores_dict}
 
-        percent_correct = round(gr.total / gr.possible, 4) if gr.possible != 0 and not failed else "--"
+        percent_correct = round(gr.total / gr.possible, 4) if gr.possible != 0 and not failed else "NA"
         summary = gr.summary() if not failed else str(gr._catastrophic_error)
-        total_pts = gr.total if not failed else "--"
+        total_pts = gr.total if not failed else "NA"
 
         scores_dict[SCORES_DICT_TOTAL_POINTS_KEY] = total_pts
         scores_dict[SCORES_DICT_FILE_KEY] = gr.file

--- a/otter/grade/utils.py
+++ b/otter/grade/utils.py
@@ -111,7 +111,7 @@ def get_points_possible_df(scores: List[GradingResults]) -> pd.DataFrame:
     if gr_completed:
         pts_poss_dict = {t: [gr_completed[0].to_dict()[t]["possible"]] for t in gr_completed[0].to_dict()}
         pts_poss_dict[SCORES_DICT_FILE_KEY] = POINTS_POSSIBLE_LABEL
-        pts_poss_dict[SCORES_DICT_PERCENT_CORRECT_KEY] = "NA"
+        pts_poss_dict[SCORES_DICT_PERCENT_CORRECT_KEY] = float('nan')
         pts_poss_dict[SCORES_DICT_TOTAL_POINTS_KEY] = gr_completed[0].possible
         pts_poss_dict[SCORES_DICT_SUMMARY_KEY] = "--"
         pts_poss_dict[SCORES_DICT_GRADING_STATUS_KEY] = "--"
@@ -138,13 +138,13 @@ def merge_scores_to_df(scores: List[GradingResults]) -> pd.DataFrame:
         scores_dict = gr.to_dict()
         failed = gr.has_catastrophic_failure()
         if failed and not pts_poss_df.empty:
-            scores_dict = {t: ["NA"] for t in pts_poss_df.to_dict()}
+            scores_dict = {t: [float('nan')] for t in pts_poss_df.to_dict()}
         elif not failed:
             scores_dict = {t: [scores_dict[t]["score"]] for t in scores_dict}
 
-        percent_correct = round(gr.total / gr.possible, 4) if gr.possible != 0 and not failed else "NA"
+        percent_correct = round(gr.total / gr.possible, 4) if gr.possible != 0 and not failed else float('nan')
         summary = gr.summary() if not failed else str(gr._catastrophic_error)
-        total_pts = gr.total if not failed else "NA"
+        total_pts = gr.total if not failed else float('nan')
 
         scores_dict[SCORES_DICT_TOTAL_POINTS_KEY] = total_pts
         scores_dict[SCORES_DICT_FILE_KEY] = gr.file

--- a/otter/grade/utils.py
+++ b/otter/grade/utils.py
@@ -27,9 +27,6 @@ SCORES_DICT_GRADING_STATUS_KEY = "grading_status"
 class TimeoutException(Exception):
     """
     This Exception is thrown when grading a notebook exceeds the timeout value specified.
-
-    Extends:
-        Exception
     """
     pass
 
@@ -111,9 +108,9 @@ def get_points_possible_df(scores: List[GradingResults]) -> pd.DataFrame:
     if gr_completed:
         pts_poss_dict = {t: [gr_completed[0].to_dict()[t]["possible"]] for t in gr_completed[0].to_dict()}
         pts_poss_dict[SCORES_DICT_FILE_KEY] = POINTS_POSSIBLE_LABEL
-        pts_poss_dict[SCORES_DICT_PERCENT_CORRECT_KEY] = float('nan')
+        pts_poss_dict[SCORES_DICT_PERCENT_CORRECT_KEY] = 1
         pts_poss_dict[SCORES_DICT_TOTAL_POINTS_KEY] = gr_completed[0].possible
-        pts_poss_dict[SCORES_DICT_SUMMARY_KEY] = "--"
+        pts_poss_dict[SCORES_DICT_SUMMARY_KEY] = "NA"
         pts_poss_dict[SCORES_DICT_GRADING_STATUS_KEY] = "--"
         pts_poss_df = pd.DataFrame(pts_poss_dict)
     return pts_poss_df
@@ -138,13 +135,13 @@ def merge_scores_to_df(scores: List[GradingResults]) -> pd.DataFrame:
         scores_dict = gr.to_dict()
         failed = gr.has_catastrophic_failure()
         if failed and not pts_poss_df.empty:
-            scores_dict = {t: [float('nan')] for t in pts_poss_df.to_dict()}
+            scores_dict = {t: [0] for t in pts_poss_df.to_dict()}
         elif not failed:
             scores_dict = {t: [scores_dict[t]["score"]] for t in scores_dict}
 
-        percent_correct = round(gr.total / gr.possible, 4) if gr.possible != 0 and not failed else float('nan')
+        percent_correct = round(gr.total / gr.possible, 4) if gr.possible != 0 and not failed else 0
         summary = gr.summary() if not failed else str(gr._catastrophic_error)
-        total_pts = gr.total if not failed else float('nan')
+        total_pts = gr.total if not failed else 0
 
         scores_dict[SCORES_DICT_TOTAL_POINTS_KEY] = total_pts
         scores_dict[SCORES_DICT_FILE_KEY] = gr.file

--- a/otter/grade/utils.py
+++ b/otter/grade/utils.py
@@ -24,6 +24,16 @@ SCORES_DICT_SUMMARY_KEY = "summary"
 SCORES_DICT_GRADING_STATUS_KEY = "grading_status"
 
 
+class TimeoutException(Exception):
+    """
+    This Exception is thrown when grading a notebook exceeds the timeout value specified.
+
+    Extends:
+        Exception
+    """
+    pass
+
+
 def list_files(path):
     """
     Returns a list of all non-hidden files in a directory

--- a/test/test_grade/test_integration.py
+++ b/test/test_grade/test_integration.py
@@ -89,8 +89,8 @@ def test_timeout_some_notebooks_finish():
         containers = 5,
         timeout = grade_timeout,
     )
-    df_test = pd.read_csv("test/final_grades.csv")
-    assert df_test.iloc[0]["grading_status"] == "--"
+    df_test = pd.read_csv("test/final_grades.csv", na_values='--')
+    assert pd.isna(df_test.iloc[0]["grading_status"])
     assert df_test.iloc[1]["grading_status"] == "Completed"
     pattern = rf"Executing '[\w.\/-]*test\/test_grade\/files\/timeout\/1min\.ipynb' in docker container timed out in {grade_timeout} seconds"
     assert re.match(pattern, df_test.iloc[2]["grading_status"]) is not None
@@ -112,7 +112,7 @@ def test_timeout_no_notebooks_finish():
         containers = 5,
         timeout = grade_timeout,
     )
-    df_test = pd.read_csv("test/final_grades.csv")
+    df_test = pd.read_csv("test/final_grades.csv", na_values='--')
     pattern1min = rf"Executing '[\w.\/-]*test\/test_grade\/files\/timeout\/1min\.ipynb' in docker container timed out in {grade_timeout} seconds"
     pattern10s = rf"Executing '[\w.\/-]*test\/test_grade\/files\/timeout\/10s\.ipynb' in docker container timed out in {grade_timeout} seconds"
     assert re.match(pattern10s, df_test.iloc[0]["grading_status"]) is not None
@@ -135,7 +135,7 @@ def test_network(expected_points):
         no_network = True,
     )
 
-    df_test = pd.read_csv("test/final_grades.csv")
+    df_test = pd.read_csv("test/final_grades.csv", na_values='--')
 
     # sort by filename
     df_test = df_test.sort_values("file").reset_index(drop=True)
@@ -164,7 +164,7 @@ def test_notebooks_with_pdfs(expected_points):
     )
 
     # read the output and expected output
-    df_test = pd.read_csv("test/final_grades.csv")
+    df_test = pd.read_csv("test/final_grades.csv", na_values='--')
 
     # sort by filename
     df_test = df_test.sort_values("file").reset_index(drop=True)
@@ -331,7 +331,7 @@ def test_config_overrides_integration():
 
     assert output == 1.0
 
-    got = pd.read_csv("test/final_grades.csv")
+    got = pd.read_csv("test/final_grades.csv", na_values='--')
     want = pd.DataFrame([{
         "q1": 0.0,
         "q2": 2.0,
@@ -343,7 +343,7 @@ def test_config_overrides_integration():
         "percent_correct": float('nan'),
         "total_points_earned": 13.0,
         "file": POINTS_POSSIBLE_LABEL,
-        "grading_status": "--"
+        "grading_status": float('nan')
     },{
         "q1": 0.0,
         "q2": 2.0,

--- a/test/test_grade/test_integration.py
+++ b/test/test_grade/test_integration.py
@@ -89,8 +89,8 @@ def test_timeout_some_notebooks_finish():
         containers = 5,
         timeout = grade_timeout,
     )
-    df_test = pd.read_csv("test/final_grades.csv", na_values='--')
-    assert pd.isna(df_test.iloc[0]["grading_status"])
+    df_test = pd.read_csv("test/final_grades.csv")
+    assert df_test.iloc[0]["grading_status"] == "--"
     assert df_test.iloc[1]["grading_status"] == "Completed"
     pattern = rf"Executing '[\w.\/-]*test\/test_grade\/files\/timeout\/1min\.ipynb' in docker container timed out in {grade_timeout} seconds"
     assert re.match(pattern, df_test.iloc[2]["grading_status"]) is not None
@@ -112,7 +112,7 @@ def test_timeout_no_notebooks_finish():
         containers = 5,
         timeout = grade_timeout,
     )
-    df_test = pd.read_csv("test/final_grades.csv", na_values='--')
+    df_test = pd.read_csv("test/final_grades.csv")
     pattern1min = rf"Executing '[\w.\/-]*test\/test_grade\/files\/timeout\/1min\.ipynb' in docker container timed out in {grade_timeout} seconds"
     pattern10s = rf"Executing '[\w.\/-]*test\/test_grade\/files\/timeout\/10s\.ipynb' in docker container timed out in {grade_timeout} seconds"
     assert re.match(pattern10s, df_test.iloc[0]["grading_status"]) is not None
@@ -135,7 +135,7 @@ def test_network(expected_points):
         no_network = True,
     )
 
-    df_test = pd.read_csv("test/final_grades.csv", na_values='--')
+    df_test = pd.read_csv("test/final_grades.csv")
 
     # sort by filename
     df_test = df_test.sort_values("file").reset_index(drop=True)
@@ -164,7 +164,7 @@ def test_notebooks_with_pdfs(expected_points):
     )
 
     # read the output and expected output
-    df_test = pd.read_csv("test/final_grades.csv", na_values='--')
+    df_test = pd.read_csv("test/final_grades.csv")
 
     # sort by filename
     df_test = df_test.sort_values("file").reset_index(drop=True)

--- a/test/test_grade/test_integration.py
+++ b/test/test_grade/test_integration.py
@@ -213,7 +213,7 @@ def test_single_notebook_grade(mocked_launch_grade):
         "q6": 5.0,
         "q2b": 2.0,
         "q7": 1.0,
-        "percent_correct": float('nan'),
+        "percent_correct": 1,
         "total_points_earned": 15.0,
         "file": POINTS_POSSIBLE_LABEL,
         "grading_status": "--"
@@ -272,7 +272,7 @@ def test_config_overrides(mocked_launch_grade):
         "q6": 5.0,
         "q2b": 2.0,
         "q7": 1.0,
-        "percent_correct": float('nan'),
+        "percent_correct": 1,
         "total_points_earned": 15.0,
         "file": POINTS_POSSIBLE_LABEL,
         "grading_status": "--"
@@ -331,7 +331,7 @@ def test_config_overrides_integration():
 
     assert output == 1.0
 
-    got = pd.read_csv("test/final_grades.csv", na_values='--')
+    got = pd.read_csv("test/final_grades.csv")
     want = pd.DataFrame([{
         "q1": 0.0,
         "q2": 2.0,
@@ -340,10 +340,10 @@ def test_config_overrides_integration():
         "q6": 5.0,
         "q2b": 2.0,
         "q7": 1.0,
-        "percent_correct": float('nan'),
+        "percent_correct": 1,
         "total_points_earned": 13.0,
         "file": POINTS_POSSIBLE_LABEL,
-        "grading_status": float('nan')
+        "grading_status": "--"
     },{
         "q1": 0.0,
         "q2": 2.0,

--- a/test/test_grade/test_integration.py
+++ b/test/test_grade/test_integration.py
@@ -75,21 +75,48 @@ def expected_points():
 
 @pytest.mark.slow
 @pytest.mark.docker
-def test_timeout():
+def test_timeout_some_notebooks_finish():
     """
-    Check that the notebook ``1min.ipynb`` is killed due to exceeding the defined timeout.
+    Check notebook ``1min.ipynb`` is killed due to exceeding the defined timeout while notebook ``10s.ipynb`` is graded;
+    The final_grade.csv records everything correctly
     """
-    with pytest.raises(
-        Exception, match=r"Executing '[\w./-]*test/test_grade/files/timeout/1min\.ipynb' in docker " \
-            "container failed! Exit code: 137"):
-        grade(
-            name = ASSIGNMENT_NAME,
-            paths = [FILE_MANAGER.get_path("timeout/")],
-            output_dir = "test/",
-            autograder = AG_ZIP_PATH,
-            containers = 5,
-            timeout = 59,
-        )
+    grade_timeout = 30
+    grade(
+        name = ASSIGNMENT_NAME,
+        paths = [FILE_MANAGER.get_path("timeout/")],
+        output_dir = "test/",
+        autograder = AG_ZIP_PATH,
+        containers = 5,
+        timeout = grade_timeout,
+    )
+    df_test = pd.read_csv("test/final_grades.csv")
+    assert df_test.iloc[0]["grading_status"] == "--"
+    assert df_test.iloc[1]["grading_status"] == "Completed"
+    pattern = rf"Executing '[\w.\/-]*test\/test_grade\/files\/timeout\/1min\.ipynb' in docker container timed out in {grade_timeout} seconds"
+    assert re.match(pattern, df_test.iloc[2]["grading_status"]) is not None
+
+
+@pytest.mark.slow
+@pytest.mark.docker
+def test_timeout_no_notebooks_finish():
+    """
+    Check notebook ``1min.ipynb`` and ``10s.ipynb are killed due to exceeding the defined timeout;
+    The final_grade.csv records everything correctly
+    """
+    grade_timeout = 5
+    grade(
+        name = ASSIGNMENT_NAME,
+        paths = [FILE_MANAGER.get_path("timeout/")],
+        output_dir = "test/",
+        autograder = AG_ZIP_PATH,
+        containers = 5,
+        timeout = grade_timeout,
+    )
+    df_test = pd.read_csv("test/final_grades.csv")
+    pattern1min = rf"Executing '[\w.\/-]*test\/test_grade\/files\/timeout\/1min\.ipynb' in docker container timed out in {grade_timeout} seconds"
+    pattern10s = rf"Executing '[\w.\/-]*test\/test_grade\/files\/timeout\/10s\.ipynb' in docker container timed out in {grade_timeout} seconds"
+    assert re.match(pattern10s, df_test.iloc[0]["grading_status"]) is not None
+    assert re.match(pattern1min, df_test.iloc[1]["grading_status"]) is not None
 
 
 @pytest.mark.slow
@@ -186,9 +213,10 @@ def test_single_notebook_grade(mocked_launch_grade):
         "q6": 5.0,
         "q2b": 2.0,
         "q7": 1.0,
-        "percent_correct": float('nan'),
+        "percent_correct": "--",
         "total_points_earned": 15.0,
         "file": POINTS_POSSIBLE_LABEL,
+        "grading_status": "--"
     },{
         "q1": 2.0,
         "q2": 2.0,
@@ -200,6 +228,7 @@ def test_single_notebook_grade(mocked_launch_grade):
         "percent_correct": 0.933333,
         "total_points_earned": 14.0,
         "file": "passesAll.ipynb",
+        "grading_status": "Completed"
     }])
 
     notebook_path = FILE_MANAGER.get_path("notebooks/passesAll.ipynb")
@@ -243,9 +272,10 @@ def test_config_overrides(mocked_launch_grade):
         "q6": 5.0,
         "q2b": 2.0,
         "q7": 1.0,
-        "percent_correct": float('nan'),
+        "percent_correct": "--",
         "total_points_earned": 15.0,
         "file": POINTS_POSSIBLE_LABEL,
+        "grading_status": "--"
     },{
         "q1": 2.0,
         "q2": 2.0,
@@ -257,6 +287,7 @@ def test_config_overrides(mocked_launch_grade):
         "percent_correct": 1.0,
         "total_points_earned": 15.0,
         "file": "passesAll.ipynb",
+        "grading_status": "Completed"
     }])]
 
     notebook_path = FILE_MANAGER.get_path("notebooks/passesAll.ipynb")
@@ -309,9 +340,10 @@ def test_config_overrides_integration():
         "q6": 5.0,
         "q2b": 2.0,
         "q7": 1.0,
-        "percent_correct": float('nan'),
+        "percent_correct": "--",
         "total_points_earned": 13.0,
         "file": POINTS_POSSIBLE_LABEL,
+        "grading_status": "--"
     },{
         "q1": 0.0,
         "q2": 2.0,
@@ -320,9 +352,10 @@ def test_config_overrides_integration():
         "q6": 5.0,
         "q2b": 2.0,
         "q7": 1.0,
-        "percent_correct": 1.0,
+        "percent_correct": "1.0",
         "total_points_earned": 13.0,
         "file": os.path.splitext(os.path.basename(ZIP_SUBM_PATH))[0],
+        "grading_status": "Completed"
     }])
 
     # Sort the columns by label so the dataframes can be compared with ==.

--- a/test/test_grade/test_integration.py
+++ b/test/test_grade/test_integration.py
@@ -213,7 +213,7 @@ def test_single_notebook_grade(mocked_launch_grade):
         "q6": 5.0,
         "q2b": 2.0,
         "q7": 1.0,
-        "percent_correct": "--",
+        "percent_correct": float('nan'),
         "total_points_earned": 15.0,
         "file": POINTS_POSSIBLE_LABEL,
         "grading_status": "--"
@@ -272,7 +272,7 @@ def test_config_overrides(mocked_launch_grade):
         "q6": 5.0,
         "q2b": 2.0,
         "q7": 1.0,
-        "percent_correct": "--",
+        "percent_correct": float('nan'),
         "total_points_earned": 15.0,
         "file": POINTS_POSSIBLE_LABEL,
         "grading_status": "--"
@@ -340,7 +340,7 @@ def test_config_overrides_integration():
         "q6": 5.0,
         "q2b": 2.0,
         "q7": 1.0,
-        "percent_correct": "--",
+        "percent_correct": float('nan'),
         "total_points_earned": 13.0,
         "file": POINTS_POSSIBLE_LABEL,
         "grading_status": "--"
@@ -352,7 +352,7 @@ def test_config_overrides_integration():
         "q6": 5.0,
         "q2b": 2.0,
         "q7": 1.0,
-        "percent_correct": "1.0",
+        "percent_correct": 1.0,
         "total_points_earned": 13.0,
         "file": os.path.splitext(os.path.basename(ZIP_SUBM_PATH))[0],
         "grading_status": "Completed"


### PR DESCRIPTION
This allows notebooks to timeout but not kill the entire otter grade process. 

final_grades.csv now records the status of the notebook in terms of grading completion as a column. 

If a notebook times out this is indicated while notebooks that have not timed out will record their scores.

Closes #813