### PR TITLE
Add support for qmd

### DIFF
--- a/test/test_run/files/qmd-autograder/source/otter_config.json
+++ b/test/test_run/files/qmd-autograder/source/otter_config.json
@@ -1,0 +1,4 @@
+{
+    "lang": "r",
+    "autograder_dir": "test/test_run/files/qmd-autograder"
+}

--- a/test/test_run/files/qmd-autograder/source/tests/q1.R
+++ b/test/test_run/files/qmd-autograder/source/tests/q1.R
@@ -1,0 +1,39 @@
+test = list(
+  name = "q1",
+  cases = list(
+    ottr::TestCase$new(
+      hidden = FALSE,
+      name = NA,
+      points = 1,
+      code = {
+        testthat::expect_true(is.numeric(x))
+      }
+    ),
+    ottr::TestCase$new(
+      hidden = FALSE,
+      name = NA,
+      points = 1,
+      code = {
+        testthat::expect_true(0 < x)
+        testthat::expect_true(x < 100)
+      }
+    ),
+    ottr::TestCase$new(
+      hidden = TRUE,
+      name = NA,
+      points = 1,
+      code = {
+        testthat::expect_equal(x, 2)
+      }
+    ),
+    ottr::TestCase$new(
+      hidden = TRUE,
+      name = "q1d",
+      points = 2,
+      success_message = "congrats",
+      code = {
+        testthat::expect_equal(as.character(x), "2")
+      }
+    )
+  )
+)

--- a/test/test_run/files/qmd-autograder/submission/hw01.qmd
+++ b/test/test_run/files/qmd-autograder/submission/hw01.qmd
@@ -1,0 +1,16 @@
+---
+title: "Homework 1"
+format: pdf_document
+date: '2022-07-17'
+assignment_name: "hw01"
+---
+
+**Question 1:** Assign `x` to the value `2`.
+
+```{r}
+x <- 2
+```
+
+```{r}
+. = ottr::check("tests/q1.R")
+```


### PR DESCRIPTION
First working on setting up tests for `.qmd`. I added a set of files under `test/test_run/qmd_autograder`, and started editing `test/test_run/test_integration.py` to test them. My initial step was to duplicate all the `rmd` functions and rename them `qmd` (easiest to do in first pass). But that was not possible for `get_config_path` and `load_config`.

@chrispyles - would love you to look at my logic for `get_config_path` and `load_config`. The original logic was if `rmd` was `False` then `dirname = "autograder"` but that doesn't allow for `qmd`. So I've tried to add a second argument `qmd` to allow to use the `qmd` config path. 