### PR TITLE
fix: normalize numpy 2.x boolean reprs in doctest output checker

### DIFF
--- a/otter/test_files/ok_test.py
+++ b/otter/test_files/ok_test.py
@@ -4,6 +4,7 @@ import doctest
 import io
 import os
 import pathlib
+import re
 
 from contextlib import redirect_stderr, redirect_stdout
 from textwrap import dedent
@@ -11,6 +12,38 @@ from typing import Any
 
 from .abstract_test import TestCase, TestCaseResult, TestFile
 from ..utils import hide_outputs
+
+
+class _NumpyBoolOutputChecker(doctest.OutputChecker):
+    """Normalize numpy 2.x boolean reprs before string comparison.
+
+    numpy 2.0 changed repr(np.bool_) from 'True'/'False' to
+    'np.True_'/'np.False_'. This checker normalizes those forms in the actual
+    output so that test cases written with plain 'True'/'False' continue to
+    pass against numpy 2.x.
+    """
+
+    _NORM = [
+        (re.compile(r"\bnp\.True_\b"), "True"),
+        (re.compile(r"\bnp\.False_\b"), "False"),
+    ]
+
+    def _normalize(self, s: str) -> str:
+        for pattern, replacement in self._NORM:
+            s = pattern.sub(replacement, s)
+        return s
+
+    def check_output(self, want: str, got: str, optionflags: int) -> bool:
+        if super().check_output(want, got, optionflags):
+            return True
+        return super().check_output(want, self._normalize(got), optionflags)
+
+    def output_difference(
+        self, example: doctest.Example, got: str, optionflags: int
+    ) -> str:
+        return super().output_difference(
+            example, self._normalize(got), optionflags
+        )
 
 
 def run_doctest(
@@ -39,7 +72,9 @@ def run_doctest(
         doctest_string,
     )
 
-    doctestrunner = doctest.DocTestRunner(verbose=True)
+    doctestrunner = doctest.DocTestRunner(
+        verbose=True, checker=_NumpyBoolOutputChecker()
+    )
 
     run_results = io.StringIO()
     with redirect_stdout(run_results), redirect_stderr(run_results), hide_outputs():


### PR DESCRIPTION
edit:  i worked w/claude code for over an hour debugging why users were having issues running hw10 with python 3.12.  this is a legit AI-based PR, so kill me now...  i don't know this codebase, so if this if off the mark please feel free to close it.  tagging @sean-morris for visibility

edit edit:  i will be happy as a human to make any changes to this PR, rather than let claude do it's thing.  ;)

edit edit edit:  here's the repo of the image that had the issues:  https://github.com/cal-icor/base-user-image

## Why this PR

We run JupyterHub deployments for a consortium of university courses that use otter-grader to grade student notebooks. While investigating a Python 3.12 upgrade, we found doctest failures on assignments that had been passing all semester. Students were producing correct answers but otter-grader was marking them wrong.

The Python version turned out to be irrelevant. The real cause was numpy 2.0, which changed how boolean scalars display. Any environment running otter-grader against numpy 2.x is affected, regardless of Python version.

## Background

`repr()` on a numpy bool used to return `'True'` or `'False'`. In numpy 2.x it now returns `'np.True_'` or `'np.False_'`.

otter-grader's `run_doctest()` uses Python's `doctest.DocTestRunner`, which compares actual output to the expected string verbatim. Any test case checking the result of `np.isclose()`, `np.all()`, or any other numpy expression that returns a boolean scalar now fails with:

```
Expected: True
Got:      np.True_
```

## What changed

Added `_NumpyBoolOutputChecker`, a `doctest.OutputChecker` subclass in `otter/test_files/ok_test.py`. It normalizes `np.True_` and `np.False_` in actual output before the string comparison runs. If the original comparison passes, nothing changes. If it fails, the checker tries again against the normalized form.

`DocTestRunner` in `run_doctest()` now takes the custom checker:

```python
doctestrunner = doctest.DocTestRunner(
    verbose=True, checker=_NumpyBoolOutputChecker()
)
```

## Why not fix the test cases

You could wrap numpy bool expressions in `bool()` at every call site. That works, but it puts the burden on notebook authors to track a numpy internals change and update every affected test. This fix sits in one place and doesn't require touching any existing or future test cases.