### PR TITLE
Add support for grading in Jupyterlite environment

### DIFF
--- a/otter/check/__init__.py
+++ b/otter/check/__init__.py
@@ -50,7 +50,7 @@ def main(
     question: Optional[str] = None,
     seed: Optional[int] = None,
     log_server: bool = True,
-    execute_submission: bool = True,
+    precomputed_results: Optional[str] = None,
 ):
     """
     Runs Otter Check
@@ -104,7 +104,7 @@ def main(
             script=script,
             seed=seed,
             log_server=log_server,
-            execute_submission=execute_submission,
+            precomputed_results=precomputed_results,
         )
 
         percentage = results.total / results.possible

--- a/otter/check/__init__.py
+++ b/otter/check/__init__.py
@@ -49,6 +49,8 @@ def main(
     tests_path: str = "./tests",
     question: Optional[str] = None,
     seed: Optional[int] = None,
+    log_server: bool = True,
+    execute_submission: bool = True,
 ):
     """
     Runs Otter Check
@@ -101,6 +103,8 @@ def main(
             test_dir=tests_path,
             script=script,
             seed=seed,
+            log_server=log_server,
+            execute_submission=execute_submission,
         )
 
         percentage = results.total / results.possible

--- a/otter/execute/__init__.py
+++ b/otter/execute/__init__.py
@@ -33,7 +33,7 @@ def grade_notebook(
     plugin_collection: Optional[PluginCollection] = None,
     force_python3_kernel: bool = True,
     log_server: bool = True,
-    execute_submission: bool = True,
+    precomputed_results: Optional[str] = None,
 ):
     """
     Grade an assignment file and return grade information.
@@ -109,7 +109,7 @@ def grade_notebook(
             gp = GradingPreprocessor(config=c)
             nb, _ = gp.preprocess(nb)
 
-            if execute_submission:
+            if precomputed_results is None:
                 from nbconvert.preprocessors import ExecutePreprocessor
 
                 ep = ExecutePreprocessor(config=c)
@@ -127,7 +127,8 @@ def grade_notebook(
         os.close(results_handle)
 
         try:
-            with open(results_file, "rb") as f:
+            results_file_path = precomputed_results if precomputed_results is not None else results_file
+            with open(results_file_path, "rb") as f:
                 results = pickle.load(f)
         except Exception as e:
             results = GradingResults.without_results(e)

--- a/otter/run/__init__.py
+++ b/otter/run/__init__.py
@@ -25,6 +25,8 @@ def main(
     no_logo: bool = False,
     debug: bool = False,
     extra_submission_files: Optional[list[str]] = None,
+    log_server: bool = True,
+    execute_submission: bool = True,
 ) -> GradingResults:
     """
     Grades a single submission using the autograder configuration ``autograder`` without
@@ -78,7 +80,7 @@ def main(
             shutil.copy(file, os.path.join(ag_dir, "submission", file))
 
         logo = not no_logo
-        run_autograder_main(ag_dir, logo=logo, debug=debug, otter_run=True)
+        run_autograder_main(ag_dir, logo=logo, debug=debug, otter_run=True, log_server=log_server, execute_submission=execute_submission)
 
         results_path = os.path.join(ag_dir, "results", "results.json")
         if output_dir:

--- a/otter/run/__init__.py
+++ b/otter/run/__init__.py
@@ -26,7 +26,7 @@ def main(
     debug: bool = False,
     extra_submission_files: Optional[list[str]] = None,
     log_server: bool = True,
-    execute_submission: bool = True,
+    precomputed_results: Optional[str] = None,
 ) -> GradingResults:
     """
     Grades a single submission using the autograder configuration ``autograder`` without
@@ -80,7 +80,7 @@ def main(
             shutil.copy(file, os.path.join(ag_dir, "submission", file))
 
         logo = not no_logo
-        run_autograder_main(ag_dir, logo=logo, debug=debug, otter_run=True, log_server=log_server, execute_submission=execute_submission)
+        run_autograder_main(ag_dir, logo=logo, debug=debug, otter_run=True, log_server=log_server, precomputed_results=precomputed_results)
 
         results_path = os.path.join(ag_dir, "results", "results.json")
         if output_dir:

--- a/otter/run/run_autograder/autograder_config.py
+++ b/otter/run/run_autograder/autograder_config.py
@@ -178,5 +178,15 @@ class AutograderConfig(fica.Config):
         default=False,
     )
 
+    log_server: bool = fica.Key(
+        description="Whether to start a logging server for the autograder",
+        default=True,
+    )
+
+    execute_submission: bool = fica.Key(
+        description="Whether to execute the submission code. You can set to false if you provide a jupyter notebook that is already executed.",
+        default=True,
+    )
+
     otter_run: bool = False
     """whether this autograder run is being run by Otter Run (i.e. without containerization)"""

--- a/otter/run/run_autograder/autograder_config.py
+++ b/otter/run/run_autograder/autograder_config.py
@@ -183,9 +183,9 @@ class AutograderConfig(fica.Config):
         default=True,
     )
 
-    execute_submission: bool = fica.Key(
-        description="Whether to execute the submission code. You can set to false if you provide a jupyter notebook that is already executed.",
-        default=True,
+    precomputed_results: Optional[str] = fica.Key(
+        description="Optional path to the precomputed results file. If this path is provided, the notebook will not be executed.",
+        default=None,
     )
 
     otter_run: bool = False

--- a/otter/run/run_autograder/runners/python_runner.py
+++ b/otter/run/run_autograder/runners/python_runner.py
@@ -133,6 +133,8 @@ class PythonRunner(AbstractLanguageRunner):
                 plugin_collection=plugin_collection,
                 script=os.path.splitext(subm_path)[1] == ".py",
                 force_python3_kernel=not self.ag_config.otter_run,
+                log_server=self.ag_config.log_server,
+                execute_submission=self.ag_config.execute_submission,
             )
 
             if pdf_error:

--- a/otter/run/run_autograder/runners/python_runner.py
+++ b/otter/run/run_autograder/runners/python_runner.py
@@ -134,7 +134,7 @@ class PythonRunner(AbstractLanguageRunner):
                 script=os.path.splitext(subm_path)[1] == ".py",
                 force_python3_kernel=not self.ag_config.otter_run,
                 log_server=self.ag_config.log_server,
-                execute_submission=self.ag_config.execute_submission,
+                precomputed_results=self.ag_config.precomputed_results,
             )
 
             if pdf_error:


### PR DESCRIPTION
As part of a [project](https://github.com/crt25/collimator) in collaboration with the [University of Teacher Education, State of Vaud (HEP Vaud)](https://www.hepl.ch/), we adapted Otter so that the grading could be run within Jupyterlite, directly within students' browsers, without revealing the solutions. The idea is obviously not to use this for actual grading, but rather as part of in-class exercises, where the stakes are lower.

This is the minimal set of changes necessary to enable such an application: we selectively allow for disabling the log server and allow Otter Grader to accept pre-computed results as a parameter.

In our application, we [pre-compute the results](https://github.com/crt25/collimator/blob/a0813f31214e94f81388f3af82a04ed18d3d6b41/apps/jupyter/extensions/notebook-runner/src/commands/grade.ts#L86-L165) by manually merging the autograder and the student notebook, run it and pass the results to the grader.

Would you be open to merging this back into otter-grader?